### PR TITLE
proposer: fix da rpc, estimate gas

### DIFF
--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -38,6 +38,12 @@ var (
 			"creating a new batch",
 		EnvVar: opservice.PrefixEnvVar(envVarPrefix, "POLL_INTERVAL"),
 	}
+	DaRpcFlag = cli.StringFlag{
+		Name:     "da-rpc",
+		Usage:    "HTTP provider URL for DA node",
+		Required: true,
+		EnvVar:   opservice.PrefixEnvVar(envVarPrefix, "DA_RPC"),
+	}
 	// Optional flags
 	AllowNonFinalizedFlag = cli.BoolFlag{
 		Name:   "allow-non-finalized",
@@ -53,6 +59,7 @@ var requiredFlags = []cli.Flag{
 	RollupRpcFlag,
 	L2OOAddressFlag,
 	PollIntervalFlag,
+	DaRpcFlag,
 }
 
 var optionalFlags = []cli.Flag{

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -328,9 +328,11 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output *eth.Out
 		return err
 	}
 	receipt, err := l.txMgr.Send(ctx, txmgr.TxCandidate{
-		TxData:   data,
-		To:       &l.l2ooContractAddr,
-		GasLimit: 0,
+		TxData: data,
+		To:     &l.l2ooContractAddr,
+		// Use manual limit as proposer tx data may be to small
+		// t=2023-04-28T00:59:37+0000 lvl=warn msg="estimating gas"                     service=proposer gas=87698
+		GasLimit: 100000,
 	})
 	if err != nil {
 		return err

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -292,6 +292,7 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 			GasTipCap: gasTipCap,
 			Data:      rawTx.Data,
 		})
+		m.l.Warn("estimating gas", "candidate", candidate, "gasFeeCap", gasFeeCap, "gasTipCap", gasTipCap, "err", err)
 		if err != nil {
 			return nil, fmt.Errorf("failed to estimate gas: %w", err)
 		}

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -123,6 +123,7 @@ services:
       OP_PROPOSER_METRICS_ENABLED: "true"
       OP_PROPOSER_ALLOW_NON_FINALIZED: "true"
       OP_PROPOSER_NAMESPACE_ID: "e8e5f679bf7116cb"
+      OP_PROPOSER_DA_RPC: http://da:26659
 
   op-batcher:
     depends_on:


### PR DESCRIPTION
This PR fixes #18 by setting the DA RPC flag and fixing gas estimation for proposal transactions.

Also including a log for debugging gas estimation.