### PR TITLE
op-node: fix failed to parse frame error

### DIFF
--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -123,7 +123,6 @@ func DataFromEVMTransactions(config *rollup.Config, daCfg *rollup.DAConfig, batc
 				log.Warn("tx in inbox with unauthorized submitter", "index", j, "err", err)
 				continue // not an authorized batch submitter, ignore
 			}
-			out = append(out, tx.Data())
 
 			height, index, err := decodeETHData(tx.Data())
 			if err != nil {


### PR DESCRIPTION
This PR fixes #19 which was happening because we were appending both the frame pointer as well as the frame data in the data returned from `DataFromEVMTransactions`.

Fixed by removing the offending line.