### PR TITLE
proposer: fix revert

### DIFF
--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -330,7 +330,6 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output *eth.Out
 	receipt, err := l.txMgr.Send(ctx, txmgr.TxCandidate{
 		TxData: data,
 		To:     &l.l2ooContractAddr,
-		GasLimit: 0,
 	})
 	if err != nil {
 		return err

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -332,7 +332,7 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output *eth.Out
 		To:     &l.l2ooContractAddr,
 		// Use manual limit as proposer tx data may be to small
 		// t=2023-04-28T00:59:37+0000 lvl=warn msg="estimating gas"                     service=proposer gas=87698
-		GasLimit: 100000,
+		GasLimit: 500000,
 	})
 	if err != nil {
 		return err

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -330,9 +330,7 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output *eth.Out
 	receipt, err := l.txMgr.Send(ctx, txmgr.TxCandidate{
 		TxData: data,
 		To:     &l.l2ooContractAddr,
-		// Use manual limit as proposer tx data may be to small
-		// t=2023-04-28T00:59:37+0000 lvl=warn msg="estimating gas"                     service=proposer gas=87698
-		GasLimit: 500000,
+		GasLimit: 0,
 	})
 	if err != nil {
 		return err

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -213,6 +213,11 @@ func (m *SimpleTxManager) send(ctx context.Context, candidate TxCandidate) (*typ
 		ctx, cancel = context.WithTimeout(ctx, m.cfg.TxSendTimeout)
 		defer cancel()
 	}
+	// TODO: this is a hack to route only batcher transactions through celestia
+	// SimpleTxManager is used by both batcher and proposer but since proposer
+	// writes to a smart contract, we overwrite _only_ batcher candidate as the
+	// frame pointer to celestia, while retaining the proposer pathway that
+	// writes the state commitment data to ethereum.
 	if candidate.To.Hex() == "0xfF00000000000000000000000000000000000000" {
 		res, err := m.daClient.SubmitPFB(ctx, m.namespaceId, candidate.TxData, 20000, 700000)
 		if err != nil {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -213,38 +213,41 @@ func (m *SimpleTxManager) send(ctx context.Context, candidate TxCandidate) (*typ
 		ctx, cancel = context.WithTimeout(ctx, m.cfg.TxSendTimeout)
 		defer cancel()
 	}
-	res, err := m.daClient.SubmitPFB(ctx, m.namespaceId, candidate.TxData, 20000, 700000)
-	if err != nil {
-		m.l.Warn("unable to publish tx to celestia", "err", err)
-		return nil, err
+	if candidate.To.Hex() == "0xfF00000000000000000000000000000000000000" {
+		res, err := m.daClient.SubmitPFB(ctx, m.namespaceId, candidate.TxData, 20000, 700000)
+		if err != nil {
+			m.l.Warn("unable to publish tx to celestia", "err", err)
+			return nil, err
+		}
+		fmt.Printf("res: %v\n", res)
+
+		height := res.Height
+
+		// FIXME: needs to be tx index / share index?
+		index := uint32(0) // res.Logs[0].MsgIndex
+
+		// DA pointer serialization format
+		// | -------------------------|
+		// | 8 bytes       | 4 bytes  |
+		// | block height | tx index  |
+		// | -------------------------|
+
+		buf := new(bytes.Buffer)
+		err = binary.Write(buf, binary.BigEndian, height)
+		if err != nil {
+			return nil, fmt.Errorf("data pointer block height serialization failed: %w", err)
+		}
+		err = binary.Write(buf, binary.BigEndian, index)
+		if err != nil {
+			return nil, fmt.Errorf("data pointer tx index serialization failed: %w", err)
+		}
+
+		serialized := buf.Bytes()
+		fmt.Printf("TxData: %v\n", serialized)
+		candidate = TxCandidate{TxData: serialized, To: candidate.To, GasLimit: candidate.GasLimit}
 	}
-	fmt.Printf("res: %v\n", res)
 
-	height := res.Height
-
-	// FIXME: needs to be tx index / share index?
-	index := uint32(0) // res.Logs[0].MsgIndex
-
-	// DA pointer serialization format
-	// | -------------------------|
-	// | 8 bytes       | 4 bytes  |
-	// | block height | tx index  |
-	// | -------------------------|
-
-	buf := new(bytes.Buffer)
-	err = binary.Write(buf, binary.BigEndian, height)
-	if err != nil {
-		return nil, fmt.Errorf("data pointer block height serialization failed: %w", err)
-	}
-	err = binary.Write(buf, binary.BigEndian, index)
-	if err != nil {
-		return nil, fmt.Errorf("data pointer tx index serialization failed: %w", err)
-	}
-
-	serialized := buf.Bytes()
-	tx, err := m.craftTx(ctx, TxCandidate{TxData: serialized, To: candidate.To, GasLimit: candidate.GasLimit})
-	fmt.Printf("TxData: %v\n", serialized)
-
+	tx, err := m.craftTx(ctx, candidate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the tx: %w", err)
 	}


### PR DESCRIPTION
This PR fixes #23 which was happening because the proposer transaction was failing with:

`proposer tx successfully published but reverted`

There were two issues here:

* Proposer transaction read from celestia is not supported, because unlike batcher transaction, the data is posted to the smart contract rather than to calldata directly, so we cannot read proposer data without reading the smart contract. To fix this, we are going to restore posting the data to ethereum instead of celestia. This should be tracked in #27
* Proposer transaction was reverting because of insufficient gas limit. The limit has been bumped.

There is some hacky code here because both batcher and proposer reuse the same code for sending out the transaction, so we need to have a ugly if around the celestia transaction. Will be thinking through improvements to this.