### PR TITLE
docker: cleanup da container name

### DIFF
--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -12,7 +12,6 @@ volumes:
 
 services:
   da:
-    container_name: da
     platform: linux/x86_64
     image: "ghcr.io/rollkit/local-celestia-devnet:v0.9.2"
     ports:


### PR DESCRIPTION
Removed `container_name` so that the default name comes up like `ops-bedrock-da-1` consistent with other container names