### PR TITLE
op-node: gracefully retry da connection err

### DIFF
--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -121,8 +121,9 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out := DataFromEVMTransactions(cfg, batcherAddr, txs, testlog.Logger(t, log.LvlCrit))
+		out, err := DataFromEVMTransactions(cfg, nil, batcherAddr, txs, testlog.Logger(t, log.LvlCrit))
 		require.ElementsMatch(t, expectedData, out)
+		require.NoError(t, err)
 	}
 
 }


### PR DESCRIPTION
## Overview

This PR allows `DataFromEVMTransactions` to return a error, so that it can be wrapped in a `TemporaryError` as a sentinel to signal that there was a temporary connection error to the DA and that the caller _must_ retry the same transactions again.

Fixes #31 

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
