### PR TITLE
test: fix e2e tests for celestia DA

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ Read through [CONTRIBUTING.md](./CONTRIBUTING.md) for a general overview of our 
 Use the [Developer Quick Start](./CONTRIBUTING.md#development-quick-start) to get your development environment set up to start working on the Optimism Monorepo.
 Then check out our list of [good first issues](https://github.com/ethereum-optimism/optimism/contribute) to find something fun to work on! -->
 
+## e2e testing
+
+This repository has updated end-to-end tests in the `op-e2e` package to work with
+Celestia as the data availability (DA) layer.
+
+Currently, the tests assume a working [Celestia devnet](https://github.com/rollkit/local-celestia-devnet) running locally:
+
+```bash
+docker run --platform linux/amd64 -p 26650:26657 -p 26659:26659 ghcr.io/rollkit/local-celestia-devnet:v0.9.5
+```
+
+The e2e tests can be triggered with:
+
+```bash
+cd $HOME/optimism
+cd op-e2e
+make test
+```
+
 ## Bridging
 
 If you have the OP Stack + Celestia setup running, you can test out bridging from the L1

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -57,6 +57,7 @@ func newTxMgrConfig(l1Addr string, privKey *ecdsa.PrivateKey) txmgr.CLIConfig {
 		ReceiptQueryInterval:      50 * time.Millisecond,
 		NetworkTimeout:            2 * time.Second,
 		TxNotInMempoolTimeout:     2 * time.Minute,
+		NamespaceId:               "e8e5f679bf7116cb",
 	}
 }
 
@@ -531,6 +532,13 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 		}
 
 		c.Rollup.LogDescription(cfg.Loggers[name], chaincfg.L2ChainIDToNetworkName)
+
+		daCfg, err := rollup.NewDAConfig("http://127.0.0.1:26659", "e8e5f679bf7116cb")
+		if err != nil {
+			return nil, err
+		}
+
+		c.DAConfig = *daCfg
 
 		node, err := rollupNode.New(context.Background(), &c, cfg.Loggers[name], snapLog, "", metrics.NewMetrics(""))
 		if err != nil {

--- a/op-program/client/boot.go
+++ b/op-program/client/boot.go
@@ -14,6 +14,7 @@ import (
 type BootInfo struct {
 	// TODO(CLI-XXX): The rollup config will be hardcoded. It's configurable for testing purposes.
 	Rollup             *rollup.Config      `json:"rollup"`
+	DAConfig           *rollup.DAConfig    `json:"da_config"`
 	L2ChainConfig      *params.ChainConfig `json:"l2_chain_config"`
 	L1Head             common.Hash         `json:"l1_head"`
 	L2Head             common.Hash         `json:"l2_head"`

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -34,8 +34,8 @@ type Driver struct {
 	targetBlockNum uint64
 }
 
-func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher, l2Source L2Source, targetBlockNum uint64) *Driver {
-	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l2Source, metrics.NoopMetrics)
+func NewDriver(logger log.Logger, cfg *rollup.Config, daCfg *rollup.DAConfig, l1Source derive.L1Fetcher, l2Source L2Source, targetBlockNum uint64) *Driver {
+	pipeline := derive.NewDerivationPipeline(logger, cfg, daCfg, l1Source, l2Source, metrics.NoopMetrics)
 	pipeline.Reset()
 	return &Driver{
 		logger:         logger,

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -52,6 +52,7 @@ func RunProgram(logger log.Logger, bootOracle io.Reader, preimageOracle io.ReadW
 	return runDerivation(
 		logger,
 		bootInfo.Rollup,
+		bootInfo.DAConfig,
 		bootInfo.L2ChainConfig,
 		bootInfo.L1Head,
 		bootInfo.L2Head,
@@ -63,7 +64,7 @@ func RunProgram(logger log.Logger, bootOracle io.Reader, preimageOracle io.ReadW
 }
 
 // runDerivation executes the L2 state transition, given a minimal interface to retrieve data.
-func runDerivation(logger log.Logger, cfg *rollup.Config, l2Cfg *params.ChainConfig, l1Head common.Hash, l2Head common.Hash, l2Claim common.Hash, l2ClaimBlockNum uint64, l1Oracle l1.Oracle, l2Oracle l2.Oracle) error {
+func runDerivation(logger log.Logger, cfg *rollup.Config, daCfg *rollup.DAConfig, l2Cfg *params.ChainConfig, l1Head common.Hash, l2Head common.Hash, l2Claim common.Hash, l2ClaimBlockNum uint64, l1Oracle l1.Oracle, l2Oracle l2.Oracle) error {
 	l1Source := l1.NewOracleL1Client(logger, l1Oracle, l1Head)
 	engineBackend, err := l2.NewOracleBackedL2Chain(logger, l2Oracle, l2Cfg, l2Head)
 	if err != nil {
@@ -72,7 +73,7 @@ func runDerivation(logger log.Logger, cfg *rollup.Config, l2Cfg *params.ChainCon
 	l2Source := l2.NewOracleEngine(cfg, logger, engineBackend)
 
 	logger.Info("Starting derivation")
-	d := cldr.NewDriver(logger, cfg, l1Source, l2Source, l2ClaimBlockNum)
+	d := cldr.NewDriver(logger, cfg, daCfg, l1Source, l2Source, l2ClaimBlockNum)
 	for {
 		if err = d.Step(context.Background()); errors.Is(err, io.EOF) {
 			break


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR updates e2e tests in the `op-e2e` package to work with celestia as the DA.

**Tests**

Currently the tests assume a working celestia devnet node running locally:

`docker run --platform linux/amd64 -p 26650:26657 -p 26659:26659 ghcr.io/rollkit/local-celestia-devnet:v0.9.5`

e2e tests can be triggered with:

`cd op-e2e`
`make test`

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #44 

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
