### PR TITLE
switch testnet to Arabica

### DIFF
--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -16,7 +16,7 @@ services:
     user: root
     platform: "${PLATFORM}"
     image: "ghcr.io/celestiaorg/celestia-node:v0.7.1"
-    command: celestia light start --core.ip https://limani.celestia-devops.dev --gateway --gateway.addr da --gateway.port 26659 --p2p.network arabica
+    command: celestia light start --core.ip https://rpc.limani.celestia-devops.dev --gateway --gateway.addr da --gateway.port 26659 --p2p.network arabica
     environment:
       - NODE_TYPE=light
       - P2P_NETWORK=arabica

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -15,13 +15,13 @@ services:
     container_name: celestia-light-node
     user: root
     platform: "${PLATFORM}"
-    image: "ghcr.io/celestiaorg/celestia-node:v0.9.5"
-    command: celestia light start --core.ip https://rpc-blockspacerace.pops.one --gateway --gateway.addr da --gateway.port 26659 --p2p.network blockspacerace
+    image: "ghcr.io/celestiaorg/celestia-node:v0.7.1"
+    command: celestia light start --core.ip https://limani.celestia-devops.dev --gateway --gateway.addr da --gateway.port 26659 --p2p.network arabica
     environment:
       - NODE_TYPE=light
-      - P2P_NETWORK=blockspacerace
+      - P2P_NETWORK=arabica
     volumes:
-      - $HOME/.celestia-light-blockspacerace-0/:/home/celestia/.celestia-light-blockspacerace-0/
+      - $HOME/.celestia-light-arabica/:/home/celestia/.celestia-light-arabica/
     ports:
       - "26657:26657"
       - "26659:26659"

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -21,7 +21,7 @@ services:
       - NODE_TYPE=light
       - P2P_NETWORK=arabica
     volumes:
-      - $HOME/.celestia-light-arabica-6/:/home/celestia/.celestia-light-arabica-6/
+      - $HOME/.celestia-light-arabica-6/:/root/.celestia-light-arabica-6/
     ports:
       - "26657:26657"
       - "26659:26659"

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -21,7 +21,7 @@ services:
       - NODE_TYPE=light
       - P2P_NETWORK=arabica
     volumes:
-      - $HOME/.celestia-light-arabica/:/home/celestia/.celestia-light-arabica/
+      - $HOME/.celestia-light-arabica-6/:/home/celestia/.celestia-light-arabica-6/
     ports:
       - "26657:26657"
       - "26659:26659"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR reverts the testnet to use Arabica instead of Blockspace Race, as BSR ends soon.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
