### PR TITLE
deps: bump celestia-node & local-celestia-devnet image version to v0.10.0

### DIFF
--- a/ops-bedrock/docker-compose-devnet.yml
+++ b/ops-bedrock/docker-compose-devnet.yml
@@ -13,7 +13,7 @@ volumes:
 services:
   da:
     platform: linux/x86_64
-    image: "ghcr.io/rollkit/local-celestia-devnet:v0.9.5"
+    image: "ghcr.io/rollkit/local-celestia-devnet:v0.10.0"
     ports:
       - "26657:26657"
       - "26659:26659"

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -16,7 +16,7 @@ services:
     user: root
     platform: "${PLATFORM}"
     image: "ghcr.io/celestiaorg/celestia-node:v0.10.0"
-    command: celestia light start --core.ip https://rpc-blockspacerace.pops.one --gateway --gateway.addr da --gateway.port 26659 --p2p.network blockspacerace
+    command: celestia light start --core.ip https://rpc-1.celestia.nodes.guru/ --gateway --gateway.addr da --gateway.port 26659 --p2p.network blockspacerace
     environment:
       - NODE_TYPE=light
       - P2P_NETWORK=blockspacerace

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -15,7 +15,7 @@ services:
     container_name: celestia-light-node
     user: root
     platform: "${PLATFORM}"
-    image: "ghcr.io/celestiaorg/celestia-node:v0.9.5"
+    image: "ghcr.io/celestiaorg/celestia-node:v0.10.0"
     command: celestia light start --core.ip https://rpc-blockspacerace.pops.one --gateway --gateway.addr da --gateway.port 26659 --p2p.network blockspacerace
     environment:
       - NODE_TYPE=light

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -16,7 +16,7 @@ services:
     user: root
     platform: "${PLATFORM}"
     image: "ghcr.io/celestiaorg/celestia-node:v0.10.0"
-    command: celestia light start --core.ip https://rpc-1.celestia.nodes.guru/ --gateway --gateway.addr da --gateway.port 26659 --p2p.network blockspacerace
+    command: celestia light start --core.ip https://celestia.rpc.waynewayner.de/ --gateway --gateway.addr da --gateway.port 26659 --p2p.network blockspacerace
     environment:
       - NODE_TYPE=light
       - P2P_NETWORK=blockspacerace


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR updates the `celestia-node` image from `v0.9.5` to `v0.10.0`. It also replaces the RPC with an RPC URL that does not result in a `max_subscriptions` error.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
