### PR TITLE
op-node: continue on retrieval error

### DIFF
--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -149,7 +149,7 @@ func DataFromEVMTransactions(config *rollup.Config, daCfg *rollup.DAConfig, batc
 				data, err := daCfg.Client.NamespacedData(context.Background(), daCfg.Namespace, uint64(height))
 				if err != nil {
 					log.Warn("unable to retrieve data from da", "err", err)
-					return nil, err
+					continue
 				}
 				log.Warn("retrieved data", "data", hex.EncodeToString(data[index]))
 				out = append(out, data[index])


### PR DESCRIPTION
## Overview

There is a persistent issue with the rollup node not progressing on safe blocks. Upon inspection, the rollup node tries to fetch frame from data but fails due to:

```
WARN [06-06|11:04:20.344] unable to retrieve data from da          origin=b83465..d34c02:9130159 err="Get \"http://localhost:26659/namespaced_data/00000000000000000000000000000000000000f92140012837778721be/height/36708\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
WARN [06-06|11:04:20.346] Failed to parse frames                   origin=b83465..d34c02:9130159 err="parsing frame 0: reading channel_id: unexpected EOF"
```

In case of an error during da retrieval, we can continue so that the derivation can proceed without trying to parse (and failing) invalid frames.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
