### PR TITLE
op-node: calldata - reset pipeline on err

### DIFF
--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -11,7 +11,7 @@ import (
 )
 
 type DataAvailabilitySource interface {
-	OpenData(ctx context.Context, id eth.BlockID, batcherAddr common.Address) DataIter
+	OpenData(ctx context.Context, id eth.BlockID, batcherAddr common.Address) (DataIter, error)
 }
 
 type NextBlockProvider interface {
@@ -53,7 +53,10 @@ func (l1r *L1Retrieval) NextData(ctx context.Context) ([]byte, error) {
 		} else if err != nil {
 			return nil, err
 		}
-		l1r.datas = l1r.dataSrc.OpenData(ctx, next.ID(), l1r.prev.SystemConfig().BatcherAddr)
+		l1r.datas, err = l1r.dataSrc.OpenData(ctx, next.ID(), l1r.prev.SystemConfig().BatcherAddr)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	l1r.log.Debug("fetching next piece of data")
@@ -73,7 +76,7 @@ func (l1r *L1Retrieval) NextData(ctx context.Context) ([]byte, error) {
 // Note that we open up the `l1r.datas` here because it is requires to maintain the
 // internal invariants that later propagate up the derivation pipeline.
 func (l1r *L1Retrieval) Reset(ctx context.Context, base eth.L1BlockRef, sysCfg eth.SystemConfig) error {
-	l1r.datas = l1r.dataSrc.OpenData(ctx, base.ID(), sysCfg.BatcherAddr)
+	l1r.datas, _ = l1r.dataSrc.OpenData(ctx, base.ID(), sysCfg.BatcherAddr)
 	l1r.log.Info("Reset of L1Retrieval done", "origin", base)
 	return io.EOF
 }


### PR DESCRIPTION
## Overview

This PR implements sentinel error handling when an error is encountered during da retrieval process.

This allows temporary da errors to be retried by signaling a pipeline reset.

## Checklist


- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
