### PR TITLE
op-node: da-rpc, namespace-id - use environment flags

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -226,12 +226,12 @@ var requiredFlags = []cli.Flag{
 	L2EngineAddr,
 	RPCListenAddr,
 	RPCListenPort,
+	DaRPC,
+	NamespaceId,
 }
 
 var optionalFlags = []cli.Flag{
 	RollupConfig,
-	DaRPC,
-	NamespaceId,
 	Network,
 	L1TrustRPC,
 	L1RPCProviderKind,

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -57,7 +57,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 
 	l2SyncEndpoint := NewL2SyncEndpointConfig(ctx)
 
-	daCfg, err := rollup.NewDAConfig(ctx.GlobalString(flags.DaRPC.Value), ctx.GlobalString(flags.NamespaceId.Value))
+	daCfg, err := rollup.NewDAConfig(ctx.GlobalString(flags.DaRPC.Name), ctx.GlobalString(flags.NamespaceId.Name))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load da config: %w", err)
 	}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -57,7 +57,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 
 	l2SyncEndpoint := NewL2SyncEndpointConfig(ctx)
 
-	daCfg, err := rollup.NewDAConfig(flags.DaRPC.Value, flags.NamespaceId.Value)
+	daCfg, err := rollup.NewDAConfig(ctx.GlobalString(flags.DaRPC.Value), ctx.GlobalString(flags.NamespaceId.Value))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load da config: %w", err)
 	}

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -91,9 +91,8 @@ services:
       --metrics.port=7300
       --pprof.enabled
       --rpc.enable-admin
-    environment:
-      OP_NODE_DA_RPC: http://da:26659
-      OP_NODE_NAMESPACE_ID: 000008e5f679bf7116cb
+      --da-rpc=http://da:26659
+      --namespace-id=000008e5f679bf7116cb
     ports:
       - "7545:8545"
       - "9003:9003"

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -61,6 +61,8 @@ services:
     build:
       context: ../
       dockerfile: ./op-node/Dockerfile
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8545"]
     command: >
       op-node
       --l1=ws://l1:8546
@@ -85,8 +87,9 @@ services:
       --metrics.port=7300
       --pprof.enabled
       --rpc.enable-admin
-      --da-rpc=http://da:26659
-      --namespace-id=000008e5f679bf7116cb
+    environment:
+      OP_NODE_DA_RPC: http://da:26659
+      OP_NODE_NAMESPACE_ID: 000008e5f679bf7116cb
     ports:
       - "7545:8545"
       - "9003:9003"

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -62,7 +62,11 @@ services:
       context: ../
       dockerfile: ./op-node/Dockerfile
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8545"]
+      test: ["CMD", "wget", "-q", "-O", "-", "http://op-node:8545"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     command: >
       op-node
       --l1=ws://l1:8546
@@ -144,7 +148,7 @@ services:
       - "7301:7300"
       - "6545:8545"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://da:26659/header/1"]
+      test: ["CMD", "wget", "-q", "-O", "-", "http://da:26659/header/1"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
**Description**

This PR updates fixes #141 and allows passing `--da-rpc`, `namespace-id` flags from the environment. 

While here also added a healthcheck for `op-node` and a better healthcheck for `celestia-node`.

**Tests**

Tested `docker-compose-testnet` with environment variables for these flags.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #141 
