### PR TITLE
devnet: bump local-celestia-devnet to v0.11.0-rc6

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Celestia as the data availability (DA) layer.
 Currently, the tests assume a working [Celestia devnet](https://github.com/rollkit/local-celestia-devnet) running locally:
 
 ```bash
-docker run --platform linux/amd64 -p 26650:26657 -p 26659:26659 ghcr.io/rollkit/local-celestia-devnet:v0.9.5
+docker run --platform linux/amd64 -p 26650:26657 -p 26659:26659 ghcr.io/rollkit/local-celestia-devnet:v0.11.0-rc6
 ```
 
 The e2e tests can be triggered with:

--- a/ops-bedrock/docker-compose-devnet.yml
+++ b/ops-bedrock/docker-compose-devnet.yml
@@ -126,10 +126,14 @@ services:
 
   op-batcher:
     depends_on:
-      - l1
-      - l2
-      - op-node
-      - da
+      l1:
+        condition: service_started
+      l2:
+        condition: service_started
+      op-node:
+        condition: service_started
+      da:
+        condition: service_healthy
     build:
       context: ../
       dockerfile: ./op-batcher/Dockerfile
@@ -137,9 +141,6 @@ services:
       - "6061:6060"
       - "7301:7300"
       - "6545:8545"
-    depends_on:
-      da:
-        condition: service_healthy
     environment:
       OP_BATCHER_L1_ETH_RPC: http://l1:8545
       OP_BATCHER_L2_ETH_RPC: http://l2:8545

--- a/ops-bedrock/docker-compose-devnet.yml
+++ b/ops-bedrock/docker-compose-devnet.yml
@@ -19,10 +19,10 @@ services:
       - "26659:26659"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:26659/header/1"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 10s
+      start_period: 30s
 
   l1:
     build:

--- a/ops-bedrock/docker-compose-devnet.yml
+++ b/ops-bedrock/docker-compose-devnet.yml
@@ -13,7 +13,7 @@ volumes:
 services:
   da:
     platform: linux/x86_64
-    image: "ghcr.io/rollkit/local-celestia-devnet:v0.10.0"
+    image: "ghcr.io/rollkit/local-celestia-devnet:v0.11.0-rc6"
     ports:
       - "26657:26657"
       - "26659:26659"

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -15,8 +15,8 @@ services:
     container_name: celestia-light-node
     user: root
     platform: "${PLATFORM}"
-    image: "ghcr.io/celestiaorg/celestia-node:v0.11.0-rc6"
-    command: celestia light start --core.ip consensus-full-arabica-9.celestia-arabica.com --gateway --gateway.addr da --gateway.port 26659  --gateway.deprecated-endpoints --p2p.network arabica
+    image: "ghcr.io/celestiaorg/celestia-node:v0.11.0-rc8"
+    command: celestia light start --core.ip consensus-full-arabica-9.celestia-arabica.com --p2p.network arabica
     environment:
       - NODE_TYPE=light
       - P2P_NETWORK=arabica

--- a/ops-bedrock/docker-compose-testnet.yml
+++ b/ops-bedrock/docker-compose-testnet.yml
@@ -92,7 +92,7 @@ services:
       --pprof.enabled
       --rpc.enable-admin
       --da-rpc=http://da:26659
-      --namespace-id=000008e5f679bf7116cb
+      --namespace-id=00000aae0236e90166d3
     ports:
       - "7545:8545"
       - "9003:9003"
@@ -129,7 +129,7 @@ services:
       OP_PROPOSER_PPROF_ENABLED: "true"
       OP_PROPOSER_METRICS_ENABLED: "true"
       OP_PROPOSER_ALLOW_NON_FINALIZED: "false"
-      OP_PROPOSER_NAMESPACE_ID: "000008e5f679bf7116cb"
+      OP_PROPOSER_NAMESPACE_ID: "00000aae0236e90166d3"
       OP_PROPOSER_DA_RPC: http://da:26659
       OP_PROPOSER_NETWORK_TIMEOUT: 180s
 
@@ -172,7 +172,7 @@ services:
       OP_BATCHER_PPROF_ENABLED: "true"
       OP_BATCHER_METRICS_ENABLED: "true"
       OP_BATCHER_RPC_ENABLE_ADMIN: "true"
-      OP_BATCHER_NAMESPACE_ID: "000008e5f679bf7116cb"
+      OP_BATCHER_NAMESPACE_ID: "00000aae0236e90166d3"
       OP_BATCHER_DA_RPC: http://da:26659
 
   stateviz:


### PR DESCRIPTION
## Overview

This PR updates the `local-celestia-devnet` version to `v0.11.0-rc6`.

While here, fix `op-batcher` dependencies and healthcheck.

Fixes #136 

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
