### PR TITLE
batcher: wait catchup before submit

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -229,6 +229,11 @@ func (m *SimpleTxManager) send(ctx context.Context, candidate TxCandidate) (*typ
 			m.l.Warn("unable to create blob commitment to celestia", "err", err)
 			return nil, err
 		}
+		err = m.daClient.DAS.WaitCatchUp(ctx)
+		if err != nil {
+			m.l.Warn("unable to wait for catchup to celestia", "err", err)
+			return nil, err
+		}
 		height, err := m.daClient.Blob.Submit(ctx, []*blob.Blob{dataBlob})
 		if err != nil {
 			m.l.Warn("unable to publish tx to celestia", "err", err)

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -229,9 +229,9 @@ func (m *SimpleTxManager) send(ctx context.Context, candidate TxCandidate) (*typ
 			m.l.Warn("unable to create blob commitment to celestia", "err", err)
 			return nil, err
 		}
-		err = m.daClient.DAS.WaitCatchUp(ctx)
+		err = m.daClient.Header.SyncWait(ctx)
 		if err != nil {
-			m.l.Warn("unable to wait for catchup to celestia", "err", err)
+			m.l.Warn("unable to wait for celestia header sync", "err", err)
 			return nil, err
 		}
 		height, err := m.daClient.Blob.Submit(ctx, []*blob.Blob{dataBlob})


### PR DESCRIPTION
## Overview

This PR adds a `WaitCatchUp` rpc request before submitting blob from `op-batcher`. This allows the batcher to gracefully handle cases where the celestia node might not be fully synced with the rest of the network.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
