### PR TITLE
.github: update base repo owner

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: tgymnich/fork-sync@v1.8
         with:
-          owner: llvm
+          owner: ethereum-optimism
           base: celesita-develop
           head: develop

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -16,3 +16,4 @@ jobs:
           owner: ethereum-optimism
           base: celesita-develop
           head: develop
+          token: ${{ secrets.REPO_PAT }}


### PR DESCRIPTION
## Overview

This PR fixes the base repo owner, it was improperly set and therefore fork sync workflow action was failing.

See: https://github.com/celestiaorg/optimism/actions/runs/6412428020/job/17409733178

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
