### PR TITLE
fix(cli): fix da rpc check

### DIFF
--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -2,7 +2,7 @@ package celestia
 
 import (
 	"fmt"
-	"net/url"
+	"net"
 
 	"github.com/urfave/cli/v2"
 
@@ -16,6 +16,24 @@ const (
 var (
 	defaultDaRpc = "localhost:26650"
 )
+
+func Check(address string) bool {
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return false
+	}
+
+	if port == "" {
+		return false
+	}
+
+	_, err = net.LookupPort("tcp", port)
+	if err != nil {
+		return false
+	}
+
+	return true
+}
 
 func CLIFlags(envPrefix string) []cli.Flag {
 	return []cli.Flag{
@@ -37,8 +55,8 @@ func (c Config) Check() error {
 		c.DaRpc = defaultDaRpc
 	}
 
-	if _, err := url.Parse(c.DaRpc); err != nil {
-		return fmt.Errorf("invalid da rpc: %w", err)
+	if !Check(c.DaRpc) {
+		return fmt.Errorf("invalid da rpc")
 	}
 
 	return nil
@@ -53,8 +71,8 @@ func (c CLIConfig) Check() error {
 		c.DaRpc = defaultDaRpc
 	}
 
-	if _, err := url.Parse(c.DaRpc); err != nil {
-		return fmt.Errorf("invalid da rpc: %w", err)
+	if !Check(c.DaRpc) {
+		return fmt.Errorf("invalid da rpc")
 	}
 
 	return nil

--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -1,6 +1,7 @@
 package celestia
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -15,24 +16,26 @@ const (
 
 var (
 	defaultDaRpc = "localhost:26650"
+
+	ErrInvalidPort = errors.New("invalid port")
 )
 
-func Check(address string) bool {
+func Check(address string) error {
 	_, port, err := net.SplitHostPort(address)
 	if err != nil {
-		return false
+		return err
 	}
 
 	if port == "" {
-		return false
+		return ErrInvalidPort
 	}
 
 	_, err = net.LookupPort("tcp", port)
 	if err != nil {
-		return false
+		return err
 	}
 
-	return true
+	return nil
 }
 
 func CLIFlags(envPrefix string) []cli.Flag {
@@ -55,8 +58,8 @@ func (c Config) Check() error {
 		c.DaRpc = defaultDaRpc
 	}
 
-	if !Check(c.DaRpc) {
-		return fmt.Errorf("invalid da rpc")
+	if err := Check(c.DaRpc); err != nil {
+		return fmt.Errorf("invalid da rpc: %w", err)
 	}
 
 	return nil
@@ -71,8 +74,8 @@ func (c CLIConfig) Check() error {
 		c.DaRpc = defaultDaRpc
 	}
 
-	if !Check(c.DaRpc) {
-		return fmt.Errorf("invalid da rpc")
+	if err := Check(c.DaRpc); err != nil {
+		return fmt.Errorf("invalid da rpc: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Overview

This PR fixes the validation for the dial address of the DA gRPC service.

Valid addresses:

* localhost:26650
* 127.0.0.1:26650
* :26650


Invalid addresses:

* localhost
* 127.0.0.1

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
