### PR TITLE
da: reuse useblobs for multiframetxs

### DIFF
--- a/op-batcher/batcher/channel_config.go
+++ b/op-batcher/batcher/channel_config.go
@@ -33,9 +33,6 @@ type ChannelConfig struct {
 	// A value of 0 disables a maximum.
 	MaxBlocksPerSpanBatch int
 
-	// MultiFrameTxs controls whether to put all frames of a channel inside a single tx.
-	MultiFrameTxs bool
-
 	// Target number of frames to create per channel.
 	// For blob transactions, this controls the number of blobs to target adding
 	// to each blob tx.

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -658,31 +658,27 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txRef
 		return nil
 	}
 
-	var candidate *txmgr.TxCandidate
-	if txdata.asBlob {
-		if candidate, err = l.blobTxCandidate(txdata); err != nil {
-			// We could potentially fall through and try a calldata tx instead, but this would
-			// likely result in the chain spending more in gas fees than it is tuned for, so best
-			// to just fail. We do not expect this error to trigger unless there is a serious bug
-			// or configuration issue.
-			return fmt.Errorf("could not create blob tx candidate: %w", err)
-		}
-	} else {
-		// sanity check
-		if nf := len(txdata.frames); nf > l.ChannelConfig.ChannelConfig().TargetNumFrames {
-			l.Log.Crit("Unexpected number of frames in calldata tx", "num_frames", nf)
-		}
-		candidate, err = l.celestiaTxCandidate(txdata.CallData())
+	// force celestia tx candidate, multiframe is set by UseBlobs which is not affected
+	txdata.asBlob = false
+	// sanity check
+	if nf := len(txdata.frames); nf > l.ChannelConfig.ChannelConfig().TargetNumFrames {
+		l.Log.Crit("Unexpected number of frames in calldata tx", "num_frames", nf)
+	}
+	candidate, err := l.celestiaTxCandidate(txdata.CallData())
+	if err != nil {
+		l.Log.Error("celestia: blob submission failed", "err", err)
+		candidate, err = l.fallbackTxCandidate(txdata)
 		if err != nil {
-			l.Log.Error("celestia: blob submission failed", "err", err)
-			candidate, err = l.fallbackTxCandidate(txdata)
-			if err != nil {
-				l.Log.Error("celestia: fallback failed", "err", err)
-				l.recordFailedTx(txdata.ID(), err)
-				return nil
-			}
+			l.Log.Error("celestia: fallback failed", "err", err)
+			l.recordFailedTx(txdata.ID(), err)
+			return nil
 		}
 	}
+	// restore asBlob for cancellation in case of blobdata fallback
+	if len(candidate.Blobs) > 0 {
+		txdata.asBlob = true
+	}
+	l.Log.Info("tx candidate", "ID", txdata.ID(), "len(txdata.frames)", len(txdata.frames), "txdata.asBlob", txdata.asBlob)
 
 	l.sendTx(txdata, false, candidate, queue, receiptsCh)
 	return nil

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -210,7 +210,6 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		MaxChannelDuration:    cfg.MaxChannelDuration,
 		MaxFrameSize:          cfg.MaxL1TxSize - 1, // account for version byte prefix; reset for blobs
 		MaxBlocksPerSpanBatch: cfg.MaxBlocksPerSpanBatch,
-		MultiFrameTxs:         cfg.MultiFrameTxs,
 		TargetNumFrames:       cfg.TargetNumFrames,
 		SubSafetyMargin:       cfg.SubSafetyMargin,
 		BatchType:             cfg.BatchType,
@@ -223,7 +222,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 
 	// enable multi-frame txs if set
 	if cfg.MultiFrameTxs {
-		cc.MultiFrameTxs = true
+		cc.UseBlobs = true
 	}
 
 	switch cfg.DataAvailabilityType {
@@ -262,7 +261,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 	bs.Log.Info("Initialized channel-config",
 		"da_type", cfg.DataAvailabilityType,
 		"use_alt_da", bs.UseAltDA,
-		"multi_frame_txs", cc.MultiFrameTxs,
+		"use_blobs", cc.UseBlobs,
 		"max_frame_size", cc.MaxFrameSize,
 		"target_num_frames", cc.TargetNumFrames,
 		"compressor", cc.CompressorConfig.Kind,


### PR DESCRIPTION
## Overview

This PR reuses the `UseBlobs` flag for multi frame transactions. OP doesn't make a distinction between multiple frames and blob da, however, we need to handle them separately to have multi frame txs, therefore some hacks around `txdata.asBlob` are required. `op-batcher` can continue to use the `multi-frame-txs` flag to enable multiframetxs on celestia.