### PR TITLE
feat: allow to toggle Celestia in op-batcher and op-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,32 @@ Celestia as the data availability (DA) layer.
 
 Currently, the tests assume a working [Celestia devnet](https://github.com/rollkit/local-celestia-devnet) running locally:
 
-```bash
-docker run -p 26650:26650 ghcr.io/rollkit/local-celestia-devnet:v0.12.7
+```sh
+CELESTIA_DEVNET_CONTAINER_ID=$(docker run -d -p 26658:26658 ghcr.io/rollkit/local-celestia-devnet:v0.13.1)
+echo "$CELESTIA_DEVNET_CONTAINER_ID"
+```
+
+To communicate with the Celestia node, we need to prepare an authentication token and a namespace:
+
+```sh
+export OP_E2E_DA_AUTH_TOKEN=$(docker exec "$CELESTIA_DEVNET_CONTAINER_ID" celestia bridge auth admin --node.store "~/bridge")
+echo "$OP_E2E_DA_AUTH_TOKEN"
+
+export OP_E2E_DA_NAMESPACE="00000000000000000000000000000000000000$(head -c 10 /dev/urandom | xxd -p -c 10)"
+echo "$OP_E2E_DA_NAMESPACE"
+
+export OP_E2E_DA_RPC='http://localhost:26658'
+export OP_E2E_DA_FALLBACK_MODE='calldata'
 ```
 
 The e2e tests can be triggered with:
 
-```bash
+```sh
 cd $HOME/optimism
 cd op-e2e
-OP_E2E_DISABLE_PARALLEL=true OP_E2E_CANNON_ENABLED=false OP_NODE_DA_RPC=localhost:26650 OP_BATCHER_DA_RPC=localhost:26650 make test
+export OP_E2E_DISABLE_PARALLEL='true'
+export OP_E2E_CANNON_ENABLED='false'
+make test
 ```
 
 ## Bridging

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ echo "$OP_E2E_DA_AUTH_TOKEN"
 export OP_E2E_DA_NAMESPACE="00000000000000000000000000000000000000$(head -c 10 /dev/urandom | xxd -p -c 10)"
 echo "$OP_E2E_DA_NAMESPACE"
 
+export OP_E2E_DA_ENABLED='true'
 export OP_E2E_DA_RPC='http://localhost:26658'
 export OP_E2E_DA_FALLBACK_MODE='calldata'
 ```

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -929,26 +929,47 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txRef
 		return nil
 	}
 
-	// force celestia tx candidate, multiframe is set by UseBlobs which is not affected
-	txdata.asBlob = false
-	// sanity check
-	if nf := len(txdata.frames); nf > l.ChannelConfig.ChannelConfig(isPectra).TargetNumFrames {
-		l.Log.Crit("Unexpected number of frames in calldata tx", "num_frames", nf)
-	}
-	candidate, err := l.celestiaTxCandidate(txdata.CallData())
-	if err != nil {
-		l.Log.Error("celestia: blob submission failed", "err", err)
-		candidate, err = l.fallbackTxCandidate(txdata)
+	var candidate *txmgr.TxCandidate
+	if l.Config.UseCelestiaDA {
+		// force celestia tx candidate, multiframe is set by UseBlobs which is not affected
+		txdata.asBlob = false
+		// sanity check
+		if nf := len(txdata.frames); nf > l.ChannelConfig.ChannelConfig(isPectra).TargetNumFrames {
+			l.Log.Crit("Unexpected number of frames in calldata tx", "num_frames", nf)
+		}
+		candidate, err = l.celestiaTxCandidate(txdata.CallData())
 		if err != nil {
-			l.Log.Error("celestia: fallback failed", "err", err)
-			l.recordFailedTx(txdata.ID(), err)
-			return nil
+			l.Log.Error("celestia: blob submission failed", "err", err)
+			candidate, err = l.fallbackTxCandidate(txdata)
+			if err != nil {
+				l.Log.Error("celestia: fallback failed", "err", err)
+				l.recordFailedTx(txdata.ID(), err)
+				return nil
+			}
+		}
+		// restore asBlob for cancellation in case of blobdata fallback
+		if len(candidate.Blobs) > 0 {
+			txdata.asBlob = true
+		}
+	} else {
+		// original behaviour from upstream/develop
+		if txdata.asBlob {
+			if candidate, err = l.blobTxCandidate(txdata); err != nil {
+				// We could potentially fall through and try a calldata tx instead, but this would
+				// likely result in the chain spending more in gas fees than it is tuned for, so best
+				// to just fail. We do not expect this error to trigger unless there is a serious bug
+				// or configuration issue.
+				return fmt.Errorf("could not create blob tx candidate: %w", err)
+			}
+		} else {
+			// sanity check
+			if nf := len(txdata.frames); nf != 1 {
+				l.Log.Crit("Unexpected number of frames in calldata tx", "num_frames", nf)
+			}
+			candidate = l.calldataTxCandidate(txdata.CallData())
 		}
 	}
-	// restore asBlob for cancellation in case of blobdata fallback
-	if len(candidate.Blobs) > 0 {
-		txdata.asBlob = true
-	}
+
 	l.Log.Info("tx candidate", "ID", txdata.ID(), "len(txdata.frames)", len(txdata.frames), "txdata.asBlob", txdata.asBlob)
 
 	l.sendTx(txdata, false, candidate, queue, receiptsCh)

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -415,7 +415,7 @@ func (bs *BatcherService) initAltDA(cfg *CLIConfig) error {
 }
 
 func (bs *BatcherService) initDA(cfg *CLIConfig) error {
-	if !cfg.DaConfig.Enabled {
+	if !cfg.DaConfig.IsEnabled() {
 		bs.UseCelestiaDA = false
 		bs.DAClient = nil
 		return nil

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -37,6 +37,10 @@ type BatcherConfig struct {
 	PollInterval           time.Duration
 	MaxPendingTransactions uint64
 
+	// If UseCelestiaDA is true, the batcher will post inputs to Celestia.
+	// Note: UseAltDA has higher precedence - if UseAltDA is true,
+	// then this flag is ignored, and AltDA will be used instead.
+	UseCelestiaDA bool
 	// UseAltDA is true if the rollup config has a DA challenge address so the batcher
 	// will post inputs to the DA server and post commitments to blobs or calldata.
 	UseAltDA bool
@@ -411,11 +415,18 @@ func (bs *BatcherService) initAltDA(cfg *CLIConfig) error {
 }
 
 func (bs *BatcherService) initDA(cfg *CLIConfig) error {
+	if !cfg.DaConfig.Enabled {
+		bs.UseCelestiaDA = false
+		bs.DAClient = nil
+		return nil
+	}
+
 	client, err := celestia.NewDAClient(cfg.DaConfig.Rpc, cfg.DaConfig.AuthToken, cfg.DaConfig.Namespace, cfg.DaConfig.FallbackMode, cfg.DaConfig.GasPrice)
 	if err != nil {
 		return err
 	}
 	bs.DAClient = client
+	bs.UseCelestiaDA = true
 	return nil
 }
 

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -139,6 +139,10 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	if err := bs.initAltDA(cfg); err != nil {
 		return fmt.Errorf("failed to init AltDA: %w", err)
 	}
+	// init before driver and channel config
+	if err := bs.initDA(cfg); err != nil {
+		return fmt.Errorf("failed to start da server: %w", err)
+	}
 	if err := bs.initChannelConfig(cfg); err != nil {
 		return fmt.Errorf("failed to init channel config: %w", err)
 	}
@@ -148,10 +152,6 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	}
 	if err := bs.initPProf(cfg); err != nil {
 		return fmt.Errorf("failed to init profiling: %w", err)
-	}
-	// init before driver
-	if err := bs.initDA(cfg); err != nil {
-		return fmt.Errorf("failed to start da server: %w", err)
 	}
 	bs.initDriver(opts...)
 	if err := bs.initRPCServer(cfg); err != nil {
@@ -288,6 +288,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 	}
 	bs.Log.Info("Initialized channel-config",
 		"da_type", cfg.DataAvailabilityType,
+		"use_celestia_da", bs.UseCelestiaDA,
 		"use_alt_da", bs.UseAltDA,
 		"use_blobs", cc.UseBlobs,
 		"max_frame_size", cc.MaxFrameSize,

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -146,9 +146,6 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 		return fmt.Errorf("failed to init profiling: %w", err)
 	}
 	// init before driver
-	if err := bs.initAltDA(cfg); err != nil {
-		return fmt.Errorf("failed to init AltDA: %w", err)
-	}
 	if err := bs.initDA(cfg); err != nil {
 		return fmt.Errorf("failed to start da server: %w", err)
 	}

--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -2,7 +2,10 @@ package celestia
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
@@ -117,4 +120,43 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 		FallbackMode: ctx.String(FallbackModeFlagName),
 		GasPrice:     ctx.Float64(GasPriceFlagName),
 	}
+}
+
+func ReadCLIConfigFromEnv(envPrefix string) CLIConfig {
+	result := CLIConfig{
+		Rpc:          defaultRPC,
+		FallbackMode: FallbackModeCallData,
+		GasPrice:     defaultGasPrice,
+	}
+
+	if value := os.Getenv(envPrefix + "_" + "DA_RPC"); value != "" {
+		result.Rpc = value
+	}
+
+	if value := os.Getenv(envPrefix + "_" + "DA_AUTH_TOKEN"); value != "" {
+		result.AuthToken = value
+	}
+
+	if value := os.Getenv(envPrefix + "_" + "DA_NAMESPACE"); value != "" {
+		result.Namespace = value
+	}
+
+	if value := os.Getenv(envPrefix + "_" + "DA_FALLBACK_MODE"); value != "" {
+		switch value {
+		case FallbackModeDisabled, FallbackModeBlobData, FallbackModeCallData:
+			result.FallbackMode = value
+		default:
+			log.Crit("invalid fallback mode", "value", value)
+		}
+	}
+
+	if value := os.Getenv(envPrefix + "_" + "DA_GAS_PRICE"); value != "" {
+		if parsed, err := strconv.ParseFloat(value, 64); err == nil {
+			result.GasPrice = parsed
+		} else {
+			log.Crit("invalid gas price", "value", value)
+		}
+	}
+
+	return result
 }

--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -22,8 +22,6 @@ const (
 )
 
 const (
-	// EnabledFlagName defines the flag for enabling Celestia
-	EnabledFlagName = "da.enabled"
 	// RPCFlagName defines the flag for the rpc url
 	RPCFlagName = "da.rpc"
 	// AuthTokenFlagName defines the flag for the auth token
@@ -49,12 +47,6 @@ const (
 
 func CLIFlags(envPrefix string) []cli.Flag {
 	return []cli.Flag{
-		&cli.BoolFlag{
-			Name:    EnabledFlagName,
-			Usage:   "enable Celestia",
-			Value:   false,
-			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_ENABLED"),
-		},
 		&cli.StringFlag{
 			Name:    RPCFlagName,
 			Usage:   "dial address of the data availability rpc client; supports grpc, http, https",
@@ -104,7 +96,6 @@ func CLIFlags(envPrefix string) []cli.Flag {
 }
 
 type CLIConfig struct {
-	Enabled      bool
 	Rpc          string
 	AuthToken    string
 	Namespace    string
@@ -112,20 +103,16 @@ type CLIConfig struct {
 	GasPrice     float64
 }
 
+func (c CLIConfig) IsEnabled() bool {
+	return c.Rpc != "" && c.AuthToken != "" && c.Namespace != ""
+}
+
 func (c CLIConfig) Check() error {
-	if c.Enabled {
-		if c.Rpc == "" {
-			return fmt.Errorf("rpc url is required when Celestia is enabled")
-		}
-		if _, err := url.Parse(c.Rpc); err != nil {
-			return fmt.Errorf("rpc url is invalid: %w", err)
-		}
-		if c.AuthToken == "" {
-			return fmt.Errorf("auth token is required when Celestia is enabled")
-		}
-		if c.Namespace == "" {
-			return fmt.Errorf("namespace is required when Celestia is enabled")
-		}
+	if !c.IsEnabled() {
+		return nil
+	}
+	if _, err := url.Parse(c.Rpc); err != nil {
+		return fmt.Errorf("rpc url is invalid: %w", err)
 	}
 	return nil
 }
@@ -138,7 +125,6 @@ func NewCLIConfig() CLIConfig {
 
 func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	return CLIConfig{
-		Enabled:      ctx.Bool(EnabledFlagName),
 		Rpc:          ctx.String(RPCFlagName),
 		AuthToken:    ctx.String(AuthTokenFlagName),
 		Namespace:    ctx.String(NamespaceFlagName),
@@ -152,14 +138,6 @@ func ReadCLIConfigFromEnv(envPrefix string) CLIConfig {
 		Rpc:          defaultRPC,
 		FallbackMode: FallbackModeCallData,
 		GasPrice:     defaultGasPrice,
-	}
-
-	if value := os.Getenv(envPrefix + "_" + "DA_ENABLED"); value != "" {
-		if parsed, err := strconv.ParseBool(value); err == nil {
-			result.Enabled = parsed
-		} else {
-			log.Crit("invalid enabled flag", "value", value)
-		}
 	}
 
 	if value := os.Getenv(envPrefix + "_" + "DA_RPC"); value != "" {

--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -1,6 +1,7 @@
 package celestia
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"os"
@@ -113,6 +114,9 @@ func (c CLIConfig) Check() error {
 	}
 	if _, err := url.Parse(c.Rpc); err != nil {
 		return fmt.Errorf("rpc url is invalid: %w", err)
+	}
+	if _, err := hex.DecodeString(c.Namespace); err != nil {
+		return fmt.Errorf("namespace is invalid hex: %w", err)
 	}
 	return nil
 }

--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -2,6 +2,7 @@ package celestia
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -21,6 +22,8 @@ const (
 )
 
 const (
+	// EnabledFlagName defines the flag for enabling Celestia
+	EnabledFlagName = "da.enabled"
 	// RPCFlagName defines the flag for the rpc url
 	RPCFlagName = "da.rpc"
 	// AuthTokenFlagName defines the flag for the auth token
@@ -46,6 +49,12 @@ const (
 
 func CLIFlags(envPrefix string) []cli.Flag {
 	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:    EnabledFlagName,
+			Usage:   "enable Celestia",
+			Value:   false,
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_ENABLED"),
+		},
 		&cli.StringFlag{
 			Name:    RPCFlagName,
 			Usage:   "dial address of the data availability rpc client; supports grpc, http, https",
@@ -95,6 +104,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 }
 
 type CLIConfig struct {
+	Enabled      bool
 	Rpc          string
 	AuthToken    string
 	Namespace    string
@@ -103,6 +113,20 @@ type CLIConfig struct {
 }
 
 func (c CLIConfig) Check() error {
+	if c.Enabled {
+		if c.Rpc == "" {
+			return fmt.Errorf("rpc url is required when Celestia is enabled")
+		}
+		if _, err := url.Parse(c.Rpc); err != nil {
+			return fmt.Errorf("rpc url is invalid: %w", err)
+		}
+		if c.AuthToken == "" {
+			return fmt.Errorf("auth token is required when Celestia is enabled")
+		}
+		if c.Namespace == "" {
+			return fmt.Errorf("namespace is required when Celestia is enabled")
+		}
+	}
 	return nil
 }
 
@@ -114,6 +138,7 @@ func NewCLIConfig() CLIConfig {
 
 func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	return CLIConfig{
+		Enabled:      ctx.Bool(EnabledFlagName),
 		Rpc:          ctx.String(RPCFlagName),
 		AuthToken:    ctx.String(AuthTokenFlagName),
 		Namespace:    ctx.String(NamespaceFlagName),
@@ -127,6 +152,14 @@ func ReadCLIConfigFromEnv(envPrefix string) CLIConfig {
 		Rpc:          defaultRPC,
 		FallbackMode: FallbackModeCallData,
 		GasPrice:     defaultGasPrice,
+	}
+
+	if value := os.Getenv(envPrefix + "_" + "DA_ENABLED"); value != "" {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			result.Enabled = parsed
+		} else {
+			log.Crit("invalid enabled flag", "value", value)
+		}
 	}
 
 	if value := os.Getenv(envPrefix + "_" + "DA_RPC"); value != "" {

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -8,6 +8,7 @@ import (
 
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
+	celestia "github.com/ethereum-optimism/optimism/op-celestia"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
@@ -189,6 +190,7 @@ func (s *interopE2ESystem) newNodeForL2(
 			SupportsPostFinalizationELSync: false,
 		},
 		ConfigPersistence: node.DisabledConfigPersistence{},
+		DaConfig:          celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 	opNode, err := opnode.NewOpnode(logger.New("service", "op-node"),
 		nodeCfg, func(err error) {
@@ -287,6 +289,7 @@ func (s *interopE2ESystem) newBatcherForL2(
 		MaxBlocksPerSpanBatch: 10,
 		DataAvailabilityType:  batcherFlags.CalldataType,
 		CompressionAlgo:       derive.Brotli,
+		DaConfig:              celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 	batcher, err := bss.BatcherServiceFromCLIConfig(
 		context.Background(), "0.0.1", batcherCLIConfig,

--- a/op-e2e/system/conductor/sequencer_failover_setup.go
+++ b/op-e2e/system/conductor/sequencer_failover_setup.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	celestia "github.com/ethereum-optimism/optimism/op-celestia"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
@@ -306,6 +307,7 @@ func setupBatcher(t *testing.T, sys *e2esys.System, conductors map[string]*condu
 		DataAvailabilityType:         batcherFlags.CalldataType,
 		ActiveSequencerCheckDuration: 0,
 		CompressionAlgo:              derive.Zlib,
+		DaConfig:                     celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 
 	batcher, err := bss.BatcherServiceFromCLIConfig(context.Background(), "0.0.1", batcherCLIConfig, sys.Cfg.Loggers["batcher"])
@@ -364,6 +366,7 @@ func sequencerCfg(conductorRPCEndpoint rollupNode.ConductorRPCFunc) *rollupNode.
 		ConductorEnabled:            true,
 		ConductorRpc:                conductorRPCEndpoint,
 		ConductorRpcTimeout:         5 * time.Second,
+		DaConfig:                    celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 }
 

--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -45,17 +45,13 @@ func TestSystem4844E2E_Calldata(t *testing.T) {
 	testSystem4844E2E(t, false, batcherFlags.CalldataType)
 }
 
-// Celestia: We disabled this test because when Celestia is used, we always write to calldata.
-// TODO: re-enable this test after we add the ability to switch off Celestia.
-// func TestSystem4844E2E_SingleBlob(t *testing.T) {
-// 	testSystem4844E2E(t, false, batcherFlags.BlobsType)
-// }
+func TestSystem4844E2E_SingleBlob(t *testing.T) {
+	testSystem4844E2E(t, false, batcherFlags.BlobsType)
+}
 
-// Celestia: We disabled this test because when Celestia is used, we always write to calldata.
-// TODO: re-enable this test after we add the ability to switch off Celestia.
-// func TestSystem4844E2E_MultiBlob(t *testing.T) {
-// 	testSystem4844E2E(t, true, batcherFlags.BlobsType)
-// }
+func TestSystem4844E2E_MultiBlob(t *testing.T) {
+	testSystem4844E2E(t, true, batcherFlags.BlobsType)
+}
 
 func testSystem4844E2E(t *testing.T, multiBlob bool, daType batcherFlags.DataAvailabilityType) {
 	op_e2e.InitParallel(t)
@@ -101,7 +97,8 @@ func testSystem4844E2E(t *testing.T, multiBlob bool, daType batcherFlags.DataAva
 	}()
 
 	cfg.DisableProposer = true // disable L2 output submission for this test
-	sys, err := cfg.Start(t, action)
+
+	sys, err := cfg.Start(t, action, e2esys.WithBatcherCelestiaDisabled()) // disable Celestia for this test
 	require.NoError(t, err, "Error starting up system")
 
 	log := testlog.Logger(t, log.LevelInfo)
@@ -278,14 +275,8 @@ func TestBatcherAutoDA(t *testing.T) {
 	cfg.DisableProposer = true // disable L2 output submission for this test
 	cfg.DisableTxForwarder = true
 	cfg.DisableBatcher = true // disable batcher because we start it manually later
-	sys, err := cfg.Start(t)
 
-	if sys.BatchSubmitter.DAClient != nil {
-		// Celestia: We disabled this test because when Celestia is used, we always write to calldata.
-		// TODO: re-enable this test after we add the ability to switch off Celestia.
-		log.Info("skipping TestBatcherAutoDA")
-		return
-	}
+	sys, err := cfg.Start(t, e2esys.WithBatcherCelestiaDisabled()) // disable Celestia for this test
 
 	require.NoError(t, err, "Error starting up system")
 	log := testlog.Logger(t, log.LevelInfo)

--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -45,13 +45,17 @@ func TestSystem4844E2E_Calldata(t *testing.T) {
 	testSystem4844E2E(t, false, batcherFlags.CalldataType)
 }
 
-func TestSystem4844E2E_SingleBlob(t *testing.T) {
-	testSystem4844E2E(t, false, batcherFlags.BlobsType)
-}
+// Celestia: We disabled this test because when Celestia is used, we always write to calldata.
+// TODO: re-enable this test after we add the ability to switch off Celestia.
+// func TestSystem4844E2E_SingleBlob(t *testing.T) {
+// 	testSystem4844E2E(t, false, batcherFlags.BlobsType)
+// }
 
-func TestSystem4844E2E_MultiBlob(t *testing.T) {
-	testSystem4844E2E(t, true, batcherFlags.BlobsType)
-}
+// Celestia: We disabled this test because when Celestia is used, we always write to calldata.
+// TODO: re-enable this test after we add the ability to switch off Celestia.
+// func TestSystem4844E2E_MultiBlob(t *testing.T) {
+// 	testSystem4844E2E(t, true, batcherFlags.BlobsType)
+// }
 
 func testSystem4844E2E(t *testing.T, multiBlob bool, daType batcherFlags.DataAvailabilityType) {
 	op_e2e.InitParallel(t)
@@ -275,6 +279,14 @@ func TestBatcherAutoDA(t *testing.T) {
 	cfg.DisableTxForwarder = true
 	cfg.DisableBatcher = true // disable batcher because we start it manually later
 	sys, err := cfg.Start(t)
+
+	if sys.BatchSubmitter.DAClient != nil {
+		// Celestia: We disabled this test because when Celestia is used, we always write to calldata.
+		// TODO: re-enable this test after we add the ability to switch off Celestia.
+		log.Info("skipping TestBatcherAutoDA")
+		return
+	}
+
 	require.NoError(t, err, "Error starting up system")
 	log := testlog.Logger(t, log.LevelInfo)
 	log.Info("genesis", "l2", sys.RollupConfig.Genesis.L2, "l1", sys.RollupConfig.Genesis.L1, "l2_time", sys.RollupConfig.Genesis.L2Time)

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -570,6 +570,14 @@ func WithBatcherCompressionAlgo(ca derive.CompressionAlgo) StartOption {
 	}
 }
 
+func WithBatcherCelestiaDisabled() StartOption {
+	return StartOption{
+		BatcherMod: func(cfg *bss.CLIConfig) {
+			cfg.DaConfig = celestia.CLIConfig{}
+		},
+	}
+}
+
 func WithBatcherThrottling(interval time.Duration, threshold, txSize, blockSize uint64) StartOption {
 	return StartOption{
 		BatcherMod: func(cfg *bss.CLIConfig) {

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -158,7 +158,7 @@ func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 				RuntimeConfigReloadInterval: time.Minute * 10,
 				ConfigPersistence:           &rollupNode.DisabledConfigPersistence{},
 				Sync:                        sync.Config{SyncMode: sync.CLSync},
-				DaConfig:                    celestia.CLIConfig{Rpc: "grpc://localhost:26650"},
+				DaConfig:                    celestia.ReadCLIConfigFromEnv("OP_E2E"),
 			},
 			RoleVerif: {
 				Driver: driver.Config{
@@ -175,7 +175,7 @@ func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 				RuntimeConfigReloadInterval: time.Minute * 10,
 				ConfigPersistence:           &rollupNode.DisabledConfigPersistence{},
 				Sync:                        sync.Config{SyncMode: sync.CLSync},
-				DaConfig:                    celestia.CLIConfig{Rpc: "grpc://localhost:26650"},
+				DaConfig:                    celestia.ReadCLIConfigFromEnv("OP_E2E"),
 			},
 		},
 		Loggers: map[string]log.Logger{
@@ -1006,7 +1006,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 		DataAvailabilityType:  sys.Cfg.DataAvailabilityType,
 		CompressionAlgo:       derive.Zlib,
 		AltDA:                 batcherAltDACLIConfig,
-		DaConfig:              celestia.CLIConfig{Rpc: "localhost:26650"},
+		DaConfig:              celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 
 	// Apply batcher cli modifications

--- a/op-e2e/system/p2p/gossip_test.go
+++ b/op-e2e/system/p2p/gossip_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	celestia "github.com/ethereum-optimism/optimism/op-celestia"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -121,6 +122,7 @@ func TestSystemDenseTopology(t *testing.T) {
 			SequencerEnabled:   false,
 		},
 		L1EpochPollInterval: time.Second * 4,
+		DaConfig:            celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 	cfg.Nodes["verifier3"] = &rollupNode.Config{
 		Driver: driver.Config{
@@ -129,6 +131,7 @@ func TestSystemDenseTopology(t *testing.T) {
 			SequencerEnabled:   false,
 		},
 		L1EpochPollInterval: time.Second * 4,
+		DaConfig:            celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 	cfg.Loggers["verifier2"] = testlog.Logger(t, log.LevelInfo).New("role", "verifier")
 	cfg.Loggers["verifier3"] = testlog.Logger(t, log.LevelInfo).New("role", "verifier")

--- a/op-e2e/system/p2p/reqresp_test.go
+++ b/op-e2e/system/p2p/reqresp_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	celestia "github.com/ethereum-optimism/optimism/op-celestia"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
@@ -46,6 +47,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 			SequencerEnabled:   false,
 		},
 		L1EpochPollInterval: time.Second * 4,
+		DaConfig:            celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 	cfg.Nodes["bob"] = &rollupNode.Config{
 		Driver: driver.Config{
@@ -54,6 +56,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 			SequencerEnabled:   false,
 		},
 		L1EpochPollInterval: time.Second * 4,
+		DaConfig:            celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 	cfg.Loggers["alice"] = testlog.Logger(t, log.LevelInfo).New("role", "alice")
 	cfg.Loggers["bob"] = testlog.Logger(t, log.LevelInfo).New("role", "bob")
@@ -128,6 +131,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 				syncedPayloads = append(syncedPayloads, payload.ExecutionPayload.ID().String())
 			},
 		},
+		DaConfig: celestia.ReadCLIConfigFromEnv("OP_E2E"),
 	}
 	e2esys.ConfigureL1(syncNodeCfg, sys.EthInstances["l1"], sys.L1BeaconEndpoint())
 	syncerL2Engine, err := geth.InitL2("syncer", sys.L2GenesisCfg, cfg.JWTFilePath)

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -86,10 +86,7 @@ func (ds *BlobDataSource) open(ctx context.Context) ([]blobOrCalldata, error) {
 		return nil, NewTemporaryError(fmt.Errorf("failed to open blob data source: %w", err))
 	}
 
-	data, hashes, err := dataAndHashesFromTxs(txs, &ds.dsCfg, ds.batcherAddr, ds.log)
-	if err != nil {
-		return nil, err
-	}
+	data, hashes := dataAndHashesFromTxs(txs, &ds.dsCfg, ds.batcherAddr, ds.log)
 
 	if len(hashes) == 0 {
 		// there are no blobs to fetch so we can return immediately
@@ -118,12 +115,11 @@ func (ds *BlobDataSource) open(ctx context.Context) ([]blobOrCalldata, error) {
 // dataAndHashesFromTxs extracts calldata and datahashes from the input transactions and returns them. It
 // creates a placeholder blobOrCalldata element for each returned blob hash that must be populated
 // by fillBlobPointers after blob bodies are retrieved.
-func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batcherAddr common.Address, logger log.Logger) ([]blobOrCalldata, []eth.IndexedBlobHash, error) {
+func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batcherAddr common.Address, logger log.Logger) ([]blobOrCalldata, []eth.IndexedBlobHash) {
 	data := []blobOrCalldata{}
 	var hashes []eth.IndexedBlobHash
 	blobIndex := 0 // index of each blob in the block's blob sidecar
 	for _, tx := range txs {
-		logger := log.New("tx", tx.Hash())
 		// skip any non-batcher transactions
 		if !isValidBatchTx(tx, config.l1Signer, config.batchInboxAddress, batcherAddr, logger) {
 			blobIndex += len(tx.BlobHashes())
@@ -131,15 +127,8 @@ func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batc
 		}
 		// handle non-blob batcher transactions by extracting their calldata
 		if tx.Type() != types.BlobTxType {
-			calldata, err := DataFromEVMTransactions(*config, batcherAddr, types.Transactions{tx}, logger)
-			if err != nil {
-				return nil, nil, err
-			}
-			if len(calldata) == 0 {
-				log.Warn("celestia: skipping empty calldata")
-				continue
-			}
-			data = append(data, blobOrCalldata{nil, &calldata[0]})
+			calldata := eth.Data(tx.Data())
+			data = append(data, blobOrCalldata{nil, &calldata})
 			continue
 		}
 		// handle blob batcher transactions by extracting their blob hashes, ignoring any calldata.
@@ -156,7 +145,7 @@ func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batc
 			blobIndex += 1
 		}
 	}
-	return data, hashes, nil
+	return data, hashes
 }
 
 // fillBlobPointers goes back through the data array and fills in the pointers to the fetched blob

--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -45,8 +45,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	calldataTx, _ := types.SignNewTx(privateKey, signer, txData)
 	txs := types.Transactions{calldataTx}
-	data, blobHashes, err := dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
-	require.NoError(t, err)
+	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -61,16 +60,14 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	blobTx, _ := types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes, err = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
-	require.NoError(t, err)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.Nil(t, data[0].calldata)
 
 	// try again with both the blob & calldata transactions and make sure both are picked up
 	txs = types.Transactions{blobTx, calldataTx}
-	data, blobHashes, err = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
-	require.NoError(t, err)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 2, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.NotNil(t, data[1].calldata)
@@ -78,8 +75,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	// make sure blob tx to the batch inbox is ignored if not signed by the batcher
 	blobTx, _ = types.SignNewTx(testutils.RandomKey(), signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes, err = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
-	require.NoError(t, err)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -88,8 +84,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	blobTxData.To = testutils.RandomAddress(rng)
 	blobTx, _ = types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes, err = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
-	require.NoError(t, err)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 

--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -2,7 +2,6 @@ package derive
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -12,16 +11,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
-	celestia "github.com/ethereum-optimism/optimism/op-celestia"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
-
-var daClient *celestia.DAClient
-
-func SetDAClient(c *celestia.DAClient) error {
-	daClient = c
-	return nil
-}
 
 // CalldataSource is a fault tolerant approach to fetching data.
 // The constructor will never fail & it will instead re-attempt the fetcher
@@ -41,7 +32,7 @@ type CalldataSource struct {
 
 // NewCalldataSource creates a new calldata source. It suppresses errors in fetching the L1 block if they occur.
 // If there is an error, it will attempt to fetch the result on the next call to `Next`.
-func NewCalldataSource(ctx context.Context, log log.Logger, dsCfg DataSourceConfig, fetcher L1TransactionFetcher, ref eth.L1BlockRef, batcherAddr common.Address) (DataIter, error) {
+func NewCalldataSource(ctx context.Context, log log.Logger, dsCfg DataSourceConfig, fetcher L1TransactionFetcher, ref eth.L1BlockRef, batcherAddr common.Address) DataIter {
 	_, txs, err := fetcher.InfoAndTxsByHash(ctx, ref.Hash)
 	if err != nil {
 		return &CalldataSource{
@@ -51,23 +42,12 @@ func NewCalldataSource(ctx context.Context, log log.Logger, dsCfg DataSourceConf
 			fetcher:     fetcher,
 			log:         log,
 			batcherAddr: batcherAddr,
-		}, nil
-	}
-	data, err := DataFromEVMTransactions(dsCfg, batcherAddr, txs, log.New("origin", ref))
-	if err != nil {
-		return &CalldataSource{
-			open:        false,
-			ref:         ref,
-			dsCfg:       dsCfg,
-			fetcher:     fetcher,
-			log:         log,
-			batcherAddr: batcherAddr,
-		}, err
+		}
 	}
 	return &CalldataSource{
 		open: true,
-		data: data,
-	}, nil
+		data: DataFromEVMTransactions(dsCfg, batcherAddr, txs, log.New("origin", ref)),
+	}
 }
 
 // Next returns the next piece of data if it has it. If the constructor failed, this
@@ -77,11 +57,7 @@ func (ds *CalldataSource) Next(ctx context.Context) (eth.Data, error) {
 	if !ds.open {
 		if _, txs, err := ds.fetcher.InfoAndTxsByHash(ctx, ds.ref.Hash); err == nil {
 			ds.open = true
-			ds.data, err = DataFromEVMTransactions(ds.dsCfg, ds.batcherAddr, txs, ds.log)
-			if err != nil {
-				// already wrapped
-				return nil, err
-			}
+			ds.data = DataFromEVMTransactions(ds.dsCfg, ds.batcherAddr, txs, ds.log)
 		} else if errors.Is(err, ethereum.NotFound) {
 			return nil, NewResetError(fmt.Errorf("failed to open calldata source: %w", err))
 		} else {
@@ -100,38 +76,12 @@ func (ds *CalldataSource) Next(ctx context.Context) (eth.Data, error) {
 // DataFromEVMTransactions filters all of the transactions and returns the calldata from transactions
 // that are sent to the batch inbox address from the batch sender address.
 // This will return an empty array if no valid transactions are found.
-func DataFromEVMTransactions(dsCfg DataSourceConfig, batcherAddr common.Address, txs types.Transactions, log log.Logger) ([]eth.Data, error) {
+func DataFromEVMTransactions(dsCfg DataSourceConfig, batcherAddr common.Address, txs types.Transactions, log log.Logger) []eth.Data {
 	out := []eth.Data{}
 	for _, tx := range txs {
 		if isValidBatchTx(tx, dsCfg.l1Signer, dsCfg.batchInboxAddress, batcherAddr, log) {
-			data := tx.Data()
-			switch len(data) {
-			case 0:
-				out = append(out, data)
-			default:
-				switch data[0] {
-				case celestia.DerivationVersionCelestia:
-					log.Info("celestia: blob request", "id", hex.EncodeToString(tx.Data()))
-					ctx, cancel := context.WithTimeout(context.Background(), daClient.GetTimeout)
-					blobs, err := daClient.Client.Get(ctx, [][]byte{data[1:]}, daClient.Namespace)
-					cancel()
-					if err != nil {
-						return nil, NewResetError(fmt.Errorf("celestia: failed to resolve frame: %w", err))
-					}
-					if len(blobs) != 1 {
-						log.Warn("celestia: unexpected length for blobs", "expected", 1, "got", len(blobs))
-						if len(blobs) == 0 {
-							log.Warn("celestia: skipping empty blobs")
-							continue
-						}
-					}
-					out = append(out, blobs[0])
-				default:
-					out = append(out, data)
-					log.Info("celestia: using eth fallback")
-				}
-			}
+			out = append(out, tx.Data())
 		}
 	}
-	return out, nil
+	return out
 }

--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -19,9 +19,6 @@ import (
 var daClient *celestia.DAClient
 
 func SetDAClient(c *celestia.DAClient) error {
-	if daClient != nil {
-		return errors.New("da client already configured")
-	}
 	daClient = c
 	return nil
 }

--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -121,10 +121,8 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out, err := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit))
-		require.NoError(t, err)
+		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit))
 		require.ElementsMatch(t, expectedData, out)
-		require.NoError(t, err)
 	}
 
 }

--- a/op-node/rollup/derive/celestia_data_source.go
+++ b/op-node/rollup/derive/celestia_data_source.go
@@ -1,0 +1,79 @@
+package derive
+
+import (
+	"context"
+	"fmt"
+
+	celestia "github.com/ethereum-optimism/optimism/op-celestia"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var daClient *celestia.DAClient
+
+func CelestiaDAEnabled() bool {
+	return daClient != nil
+}
+
+func SetCelestiaDA(c *celestia.DAClient) error {
+	daClient = c
+	return nil
+}
+
+type CelestiaDataSource struct {
+	log log.Logger
+	src DataIter
+	// keep track of a pending commitment so we can keep trying to fetch the input.
+	comm eth.Data
+}
+
+func NewCelestiaDataSource(log log.Logger, src DataIter) *CelestiaDataSource {
+	return &CelestiaDataSource{
+		log: log,
+		src: src,
+	}
+}
+
+func (s *CelestiaDataSource) Next(ctx context.Context) (eth.Data, error) {
+	if s.comm == nil {
+		// The L1 source provides the input commitment corresponding to the batch.
+		data, err := s.src.Next(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(data) == 0 {
+			return nil, NotEnoughData
+		}
+		// If the transaction data type isn't Celestia,
+		// pass it downstream for further validation
+		// and potential parsing as L1 DA inputs.
+		if data[0] != celestia.DerivationVersionCelestia {
+			return data, nil
+		}
+
+		s.comm = data[1:]
+	}
+
+	cCtx, cancel := context.WithTimeout(ctx, daClient.GetTimeout)
+	blobs, err := daClient.Client.Get(cCtx, [][]byte{s.comm}, daClient.Namespace)
+	cancel()
+
+	if err != nil {
+		return nil, NewResetError(fmt.Errorf("celestia: failed to resolve frame: %w", err))
+	}
+
+	if len(blobs) != 1 {
+		log.Warn("celestia: unexpected length for blobs", "expected", 1, "got", len(blobs))
+		if len(blobs) == 0 {
+			log.Warn("celestia: skipping empty blobs")
+			s.comm = nil
+			// skip the input
+			return s.Next(ctx)
+		}
+	}
+
+	// reset the commitment so we can fetch the next one from the source at the next iteration.
+	s.comm = nil
+	return blobs[0], nil
+}

--- a/op-node/rollup/derive/celestia_data_source.go
+++ b/op-node/rollup/derive/celestia_data_source.go
@@ -60,7 +60,8 @@ func (s *CelestiaDataSource) Next(ctx context.Context) (eth.Data, error) {
 	cancel()
 
 	if err != nil {
-		return nil, NewResetError(fmt.Errorf("celestia: failed to resolve frame: %w", err))
+		// return temporary error so we can keep retrying.
+		return nil, NewTemporaryError(fmt.Errorf("celestia: failed to resolve frame: %w", err))
 	}
 
 	if len(blobs) != 1 {

--- a/op-node/rollup/derive/celestia_data_source.go
+++ b/op-node/rollup/derive/celestia_data_source.go
@@ -65,9 +65,9 @@ func (s *CelestiaDataSource) Next(ctx context.Context) (eth.Data, error) {
 	}
 
 	if len(blobs) != 1 {
-		log.Warn("celestia: unexpected length for blobs", "expected", 1, "got", len(blobs))
+		s.log.Warn("celestia: unexpected length for blobs", "expected", 1, "got", len(blobs))
 		if len(blobs) == 0 {
-			log.Warn("celestia: skipping empty blobs")
+			s.log.Warn("celestia: skipping empty blobs")
 			s.comm = nil
 			// skip the input
 			return s.Next(ctx)

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -68,21 +68,20 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 	// Creates a data iterator from blob or calldata source so we can forward it to the altDA source
 	// if enabled as it still requires an L1 data source for fetching input commmitments.
 	var src DataIter
-	var err error
 	if ds.ecotoneTime != nil && ref.Time >= *ds.ecotoneTime {
 		if ds.blobsFetcher == nil {
 			return nil, fmt.Errorf("ecotone upgrade active but beacon endpoint not configured")
 		}
 		src = NewBlobDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr)
 	} else {
-		src, err = NewCalldataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ref, batcherAddr)
-		if err != nil {
-			return src, err
-		}
+		src = NewCalldataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ref, batcherAddr)
 	}
 	if ds.dsCfg.altDAEnabled {
 		// altDA([calldata | blobdata](l1Ref)) -> data
-		return NewAltDADataSource(ds.log, src, ds.fetcher, ds.altDAFetcher, ref), nil
+		src = NewAltDADataSource(ds.log, src, ds.fetcher, ds.altDAFetcher, ref)
+	}
+	if CelestiaDAEnabled() {
+		src = NewCelestiaDataSource(ds.log, src)
 	}
 	return src, nil
 }

--- a/op-node/rollup/driver/da.go
+++ b/op-node/rollup/driver/da.go
@@ -17,9 +17,12 @@ func SetDAClient(cfg celestia.CLIConfig) error {
 	// The read path always operates in the most permissive mode and is
 	// independent of the fallback mode.
 	// Therefore the configuration value for FallbackMode passed here does not matter.
+	if !cfg.Enabled {
+		return derive.SetCelestiaDA(nil)
+	}
 	client, err := celestia.NewDAClient(cfg.Rpc, cfg.AuthToken, cfg.Namespace, cfg.FallbackMode, cfg.GasPrice)
 	if err != nil {
 		return err
 	}
-	return derive.SetDAClient(client)
+	return derive.SetCelestiaDA(client)
 }

--- a/op-node/rollup/driver/da.go
+++ b/op-node/rollup/driver/da.go
@@ -17,7 +17,7 @@ func SetDAClient(cfg celestia.CLIConfig) error {
 	// The read path always operates in the most permissive mode and is
 	// independent of the fallback mode.
 	// Therefore the configuration value for FallbackMode passed here does not matter.
-	if !cfg.Enabled {
+	if !cfg.IsEnabled() {
 		return derive.SetCelestiaDA(nil)
 	}
 	client, err := celestia.NewDAClient(cfg.Rpc, cfg.AuthToken, cfg.Namespace, cfg.FallbackMode, cfg.GasPrice)

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	celestia "github.com/ethereum-optimism/optimism/op-celestia"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
@@ -26,6 +28,7 @@ type Config struct {
 	ForceHintChainID bool
 	DB               l2.KeyValueStore
 	StoreBlockData   bool
+	DAClient         *celestia.DAClient
 }
 
 // Main executes the client program in a detached context and exits the current process.
@@ -43,9 +46,18 @@ func Main(useInterop bool) {
 	logger.Info("Starting fault proof program client", "useInterop", useInterop)
 	preimageOracle := preimage.ClientPreimageChannel()
 	preimageHinter := preimage.ClientHinterChannel()
+
+	daCfg := celestia.ReadCLIConfigFromEnv("OP_E2E")
+	daClient, err := celestia.NewDAClient(daCfg.Rpc, daCfg.AuthToken, daCfg.Namespace, daCfg.FallbackMode, daCfg.GasPrice)
+	if err != nil {
+		log.Error("Cannot initialize daClient", "err", err)
+		os.Exit(1)
+	}
+
 	config := Config{
 		InteropEnabled: useInterop,
 		DB:             memorydb.New(),
+		DAClient:       daClient,
 	}
 	if err := RunProgram(logger, preimageOracle, preimageHinter, config); errors.Is(err, claim.ErrClaimNotValid) {
 		log.Error("Claim is invalid", "err", err)
@@ -73,6 +85,7 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 	if cfg.DB == nil {
 		return fmt.Errorf("%w: db config is required", errInvalidConfig)
 	}
+	derive.SetDAClient(cfg.DAClient)
 	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
 	derivationOptions := tasks.DerivationOptions{StoreBlockData: cfg.StoreBlockData, SkipValidation: cfg.SkipValidation}
 	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, cfg.DB, derivationOptions)

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -85,7 +85,7 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 	if cfg.DB == nil {
 		return fmt.Errorf("%w: db config is required", errInvalidConfig)
 	}
-	derive.SetDAClient(cfg.DAClient)
+	derive.SetCelestiaDA(cfg.DAClient)
 	bootInfo := boot.NewBootstrapClient(pClient).BootInfo()
 	derivationOptions := tasks.DerivationOptions{StoreBlockData: cfg.StoreBlockData, SkipValidation: cfg.SkipValidation}
 	return RunPreInteropProgram(logger, bootInfo, l1PreimageOracle, l2PreimageOracle, cfg.DB, derivationOptions)

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 
+	celestia "github.com/ethereum-optimism/optimism/op-celestia"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	cl "github.com/ethereum-optimism/optimism/op-program/client"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
@@ -150,6 +151,14 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 		clientCfg.DB = programConfig.db
 		clientCfg.StoreBlockData = programConfig.storeBlockData
 		clientCfg.ForceHintChainID = programConfig.forceHintChainID
+
+		daCfg := celestia.ReadCLIConfigFromEnv("OP_E2E")
+		daClient, err := celestia.NewDAClient(daCfg.Rpc, daCfg.AuthToken, daCfg.Namespace, daCfg.FallbackMode, daCfg.GasPrice)
+		if err != nil {
+			return fmt.Errorf("failed to initialize daClient: %w", err)
+		}
+		clientCfg.DAClient = daClient
+
 		return cl.RunProgram(logger, pClientRW, hClientRW, clientCfg)
 	}
 }


### PR DESCRIPTION
~~This PR introduces the `--da.enabled` flag, allowing Celestia support to be toggled in both `op-node` and `op-batcher`.~~

This PR disables Celestia unless all of the following flags are set: `--da.rpc`, `--da.auth_token`, `--da.namespace`.

```go
func (c CLIConfig) IsEnabled() bool {
	return c.Rpc != "" && c.AuthToken != "" && c.Namespace != ""
}
```

-------

In addition, it reverts several changes within `op-node/rollup/derive`, simplifying the process of rebasing onto the upstream repository.

Finally, it restores functionality for end-to-end (E2E) tests — the `make test` command now runs successfully.

------

Note to reviewers: You're encouraged to review the commits individually for clarity.