### PR TITLE
feat(op-celestia/indexer): add indexed l2 block status

### DIFF
--- a/op-celestia/indexer/driver.go
+++ b/op-celestia/indexer/driver.go
@@ -120,20 +120,25 @@ func (d *IndexerDriver) GetDALocation(l2BlockNum uint64) (store.DALocation, erro
 }
 
 // GetStatus returns the current status of the indexer
-func (d *IndexerDriver) GetStatus() (lastIndexedBlock uint64, indexedBlocks int, running bool, err error) {
+func (d *IndexerDriver) GetStatus() (lastIndexedBlock uint64, indexedBlocks int, running bool, l2Start uint64, l2End uint64, err error) {
 	lastIndexedBlock, err = d.Store.GetLastIndexedBlock()
 	if err != nil {
-		return 0, 0, false, fmt.Errorf("failed to get last indexed block: %w", err)
+		return 0, 0, false, 0, 0, fmt.Errorf("failed to get last indexed block: %w", err)
 	}
 
 	indexedBlocks, err = d.Store.GetIndexedBlockCount()
 	if err != nil {
-		return lastIndexedBlock, 0, false, fmt.Errorf("failed to get indexed block count: %w", err)
+		return lastIndexedBlock, 0, false, 0, 0, fmt.Errorf("failed to get indexed block count: %w", err)
+	}
+
+	l2Start, l2End, err = d.Store.GetL2BlockRange()
+	if err != nil {
+		return lastIndexedBlock, indexedBlocks, false, 0, 0, fmt.Errorf("failed to get L2 block range: %w", err)
 	}
 
 	running = d.running.Load()
 
-	return lastIndexedBlock, indexedBlocks, running, nil
+	return lastIndexedBlock, indexedBlocks, running, l2Start, l2End, nil
 }
 
 // indexingLoop is the main loop that performs indexing operations

--- a/op-celestia/indexer/rpc/api.go
+++ b/op-celestia/indexer/rpc/api.go
@@ -18,7 +18,7 @@ type IndexerAPI struct {
 // IndexerDriver interface for the indexer operations
 type IndexerDriver interface {
 	GetDALocation(l2BlockNum uint64) (store.DALocation, error)
-	GetStatus() (lastIndexedBlock uint64, indexedBlocks int, running bool, err error)
+	GetStatus() (lastIndexedBlock uint64, indexedBlocks int, running bool, l2Start uint64, l2End uint64, err error)
 }
 
 // NewIndexerAPI creates a new IndexerAPI instance
@@ -48,13 +48,15 @@ type IndexerStatusResponse struct {
 	LastIndexedBlock uint64 `json:"last_indexed_block"`
 	IndexedBlocks    int    `json:"indexed_blocks"`
 	Running          bool   `json:"running"`
+	L2StartBlock     uint64 `json:"l2_start_block"`
+	L2EndBlock       uint64 `json:"l2_end_block"`
 }
 
 // GetIndexerStatus returns the current indexer status
 func (api *IndexerAPI) GetIndexerStatus(ctx context.Context) (*IndexerStatusResponse, error) {
 	api.log.Debug("GetIndexerStatus called")
 
-	lastIndexedBlock, indexedBlocks, running, err := api.driver.GetStatus()
+	lastIndexedBlock, indexedBlocks, running, l2Start, l2End, err := api.driver.GetStatus()
 	if err != nil {
 		api.log.Warn("Failed to get indexer status", "err", err)
 		return nil, fmt.Errorf("failed to get indexer status: %w", err)
@@ -64,12 +66,16 @@ func (api *IndexerAPI) GetIndexerStatus(ctx context.Context) (*IndexerStatusResp
 		LastIndexedBlock: lastIndexedBlock,
 		IndexedBlocks:    indexedBlocks,
 		Running:          running,
+		L2StartBlock:     l2Start,
+		L2EndBlock:       l2End,
 	}
 
 	api.log.Debug("GetIndexerStatus successful",
 		"last_indexed_block", lastIndexedBlock,
 		"indexed_blocks", indexedBlocks,
-		"running", running)
+		"running", running,
+		"l2_start_block", l2Start,
+		"l2_end_block", l2End)
 
 	return response, nil
 }

--- a/op-celestia/indexer/service.go
+++ b/op-celestia/indexer/service.go
@@ -345,7 +345,7 @@ func (da *driverAdapter) GetDALocation(l2BlockNum uint64) (store.DALocation, err
 	return da.driver.GetDALocation(l2BlockNum)
 }
 
-func (da *driverAdapter) GetStatus() (lastIndexedBlock uint64, indexedBlocks int, running bool, err error) {
+func (da *driverAdapter) GetStatus() (lastIndexedBlock uint64, indexedBlocks int, running bool, l2Start uint64, l2End uint64, err error) {
 	return da.driver.GetStatus()
 }
 

--- a/op-celestia/indexer/store/memory_store.go
+++ b/op-celestia/indexer/store/memory_store.go
@@ -126,6 +126,35 @@ func (s *MemoryStore) GetIndexedBlockCount() (int, error) {
 	return len(s.l2BlockDAType), nil
 }
 
+// GetL2BlockRange returns the minimum and maximum L2 block numbers indexed
+func (s *MemoryStore) GetL2BlockRange() (min uint64, max uint64, err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.l2BlockDAType) == 0 {
+		return 0, 0, nil
+	}
+
+	// Find min and max L2 block numbers
+	first := true
+	for blockNum := range s.l2BlockDAType {
+		if first {
+			min = blockNum
+			max = blockNum
+			first = false
+		} else {
+			if blockNum < min {
+				min = blockNum
+			}
+			if blockNum > max {
+				max = blockNum
+			}
+		}
+	}
+
+	return min, max, nil
+}
+
 // Clear removes all stored data (useful for testing)
 func (s *MemoryStore) Clear() error {
 	s.mu.Lock()

--- a/op-celestia/indexer/store/sqlite_store.go
+++ b/op-celestia/indexer/store/sqlite_store.go
@@ -337,6 +337,29 @@ func (s *SqliteStore) GetIndexedBlockCount() (int, error) {
 	return count, err
 }
 
+// GetL2BlockRange returns the minimum and maximum L2 block numbers indexed
+func (s *SqliteStore) GetL2BlockRange() (min uint64, max uint64, err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	err = s.db.QueryRow(`
+		SELECT MIN(l2_block_num), MAX(l2_block_num) FROM l2_block_mappings
+	`).Scan(&min, &max)
+	
+	// Handle case where there are no blocks indexed
+	if err != nil {
+		// Check if it's because the table is empty
+		var count int
+		countErr := s.db.QueryRow(`SELECT COUNT(*) FROM l2_block_mappings`).Scan(&count)
+		if countErr == nil && count == 0 {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+	
+	return min, max, nil
+}
+
 // Clear removes all stored data (useful for testing)
 func (s *SqliteStore) Clear() error {
 	s.mu.Lock()

--- a/op-celestia/indexer/store/store.go
+++ b/op-celestia/indexer/store/store.go
@@ -21,6 +21,9 @@ type Store interface {
 	// GetIndexedBlockCount returns the number of indexed L2 blocks
 	GetIndexedBlockCount() (int, error)
 
+	// GetL2BlockRange returns the minimum and maximum L2 block numbers indexed
+	GetL2BlockRange() (min uint64, max uint64, err error)
+
 	// Clear removes all stored data
 	Clear() error
 


### PR DESCRIPTION
Adds l2 start and end block of the indexer for better qol.

Response of admin_getIndexerStatus is updated as below.

```
taehoon@succinct-gpu-06:~/celestia-optimism/op-celestia$ curl -X POST -H "Content-Type: application/json" -s \
  --data '{"jsonrpc":"2.0","method":"admin_getIndexerStatus","params":[],"id":1}' \
  http://localhost:8545 | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "last_indexed_block": 9076129,
    "indexed_blocks": 14148,
    "running": true,
    "l2_start_block": 26263190,
    "l2_end_block": 26277337
  }
}
```