### PR TITLE
da: optionally support new tx client

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -1089,7 +1089,7 @@ func (l *BatchSubmitter) celestiaTxCandidate(ctx context.Context, data []byte) (
 	if err != nil {
 		return nil, err
 	}
-	height, err := l.DAClient.Client.Blob.Submit(ctx, []*blob.Blob{b}, state.NewTxConfig(state.WithGasPrice(l.DAClient.GasPrice)))
+	height, err := l.DAClient.Client.Submit(ctx, []*blob.Blob{b}, state.NewTxConfig(state.WithGasPrice(l.DAClient.GasPrice)))
 	if err != nil {
 		return nil, err
 	}

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -461,7 +461,7 @@ func (bs *BatcherService) initDA(cfg *CLIConfig) error {
 		return nil
 	}
 
-	client, err := celestia.NewDAClient(cfg.DaConfig.Rpc, cfg.DaConfig.AuthToken, cfg.DaConfig.Namespace, cfg.DaConfig.FallbackMode, cfg.DaConfig.GasPrice)
+	client, err := celestia.NewDAClient(cfg.DaConfig.CelestiaConfig())
 	if err != nil {
 		return err
 	}

--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -26,6 +26,8 @@ const (
 const (
 	// RPCFlagName defines the flag for the rpc url
 	RPCFlagName = "da.rpc"
+	// TLSEnabledFlagName defines the flag for whether rpc TLS is enabled
+	TLSEnabledFlagName = "da.tls-enabled"
 	// AuthTokenFlagName defines the flag for the auth token
 	AuthTokenFlagName = "da.auth_token"
 	// NamespaceFlagName defines the flag for the namespace
@@ -62,6 +64,12 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Usage:   "dial address of the data availability rpc client; supports grpc, http, https",
 			Value:   defaultRPC,
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_RPC"),
+		},
+		&cli.BoolFlag{
+			Name:    TLSEnabledFlagName,
+			Usage:   "enable TLS for the data availability rpc client",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_TLS_ENABLED"),
+			Value:   true,
 		},
 		&cli.StringFlag{
 			Name:    AuthTokenFlagName,
@@ -143,6 +151,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 
 type CLIConfig struct {
 	Rpc            string
+	TLSEnabled     bool
 	AuthToken      string
 	Namespace      string
 	FallbackMode   string
@@ -166,6 +175,7 @@ func (c CLIConfig) CelestiaConfig() RPCClientConfig {
 	}
 	return RPCClientConfig{
 		URL:            c.Rpc,
+		TLSEnabled:     c.TLSEnabled,
 		AuthToken:      c.AuthToken,
 		Namespace:      ns,
 		TxClientConfig: cfg,
@@ -209,6 +219,7 @@ func NewCLIConfig() CLIConfig {
 func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	return CLIConfig{
 		Rpc:          ctx.String(RPCFlagName),
+		TLSEnabled:   ctx.Bool(TLSEnabledFlagName),
 		AuthToken:    ctx.String(AuthTokenFlagName),
 		Namespace:    ctx.String(NamespaceFlagName),
 		FallbackMode: ctx.String(FallbackModeFlagName),

--- a/op-celestia/cli.go
+++ b/op-celestia/cli.go
@@ -2,6 +2,7 @@ package celestia
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -35,6 +36,14 @@ const (
 	FallbackModeFlagName = "da.fallback_mode"
 	// GasPriceFlagName defines the flag for gas price
 	GasPriceFlagName = "da.gas_price"
+
+	// tx client config flags
+	DefaultKeyNameFlagName     = "da.tx-client.key-name"
+	KeyringPathFlagName        = "da.tx-client.keyring-path"
+	CoreGRPCAddrFlagName       = "da.tx-client.core-grpc.addr"
+	CoreGRPCTLSEnabledFlagName = "da.tx-client.core-grpc.tls-enabled"
+	CoreGRPCAuthTokenFlagName  = "da.tx-client.core-grpc.auth-token"
+	P2PNetworkFlagName         = "da.tx-client.p2p-network"
 
 	// NamespaceSize is the size of the hex encoded namespace string
 	NamespaceSize = 58
@@ -93,24 +102,94 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Value:   defaultGasPrice,
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_GAS_PRICE"),
 		},
+		&cli.StringFlag{
+			Name:    DefaultKeyNameFlagName,
+			Usage:   "celestia tx client key name",
+			Value:   "my_celes_key",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_TX_CLIENT_KEY_NAME"),
+		},
+		&cli.StringFlag{
+			Name:    KeyringPathFlagName,
+			Usage:   "celestia tx client keyring path e.g. ~/.celestia-light-mocha-4/keys",
+			Value:   "",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_TX_CLIENT_KEYRING_PATH"),
+		},
+		&cli.StringFlag{
+			Name:    CoreGRPCAddrFlagName,
+			Usage:   "celestia tx client core grpc addr",
+			Value:   "http://localhost:9090",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_TX_CLIENT_CORE_GRPC_ADDR"),
+		},
+		&cli.BoolFlag{
+			Name:    CoreGRPCTLSEnabledFlagName,
+			Usage:   "celestia tx client core grpc TLS",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_TX_CLIENT_CORE_GRPC_TLS_ENABLED"),
+			Value:   true,
+		},
+		&cli.StringFlag{
+			Name:    CoreGRPCAuthTokenFlagName,
+			Usage:   "celestia tx client core grpc auth token",
+			Value:   "",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_TX_CLIENT_CORE_GRPC_AUTH_TOKEN"),
+		},
+		&cli.StringFlag{
+			Name:    P2PNetworkFlagName,
+			Usage:   "celestia tx client p2p network",
+			Value:   "mocha-4",
+			EnvVars: opservice.PrefixEnvVar(envPrefix, "DA_TX_CLIENT_P2P_NETWORK"),
+		},
 	}
 }
 
 type CLIConfig struct {
-	Rpc          string
-	AuthToken    string
-	Namespace    string
-	FallbackMode string
-	GasPrice     float64
+	Rpc            string
+	AuthToken      string
+	Namespace      string
+	FallbackMode   string
+	GasPrice       float64
+	TxClientConfig TxClientConfig
+}
+
+func (c CLIConfig) TxClientEnabled() bool {
+	return (c.TxClientConfig.KeyringPath != "" || c.TxClientConfig.CoreGRPCAuthToken != "")
 }
 
 func (c CLIConfig) IsEnabled() bool {
 	return c.Rpc != "" && c.AuthToken != "" && c.Namespace != ""
 }
 
+func (c CLIConfig) CelestiaConfig() RPCClientConfig {
+	ns, _ := hex.DecodeString(c.Namespace)
+	var cfg *TxClientConfig
+	if c.TxClientEnabled() {
+		cfg = &c.TxClientConfig
+	}
+	return RPCClientConfig{
+		URL:            c.Rpc,
+		AuthToken:      c.AuthToken,
+		Namespace:      ns,
+		TxClientConfig: cfg,
+	}
+}
+
 func (c CLIConfig) Check() error {
 	if !c.IsEnabled() {
 		return nil
+	}
+	if c.TxClientEnabled() {
+		// If tx client is enabled, ensure tx client flags are set
+		if c.TxClientConfig.DefaultKeyName == "" {
+			return errors.New("--da.tx-client.key-name must be set")
+		}
+		if c.TxClientConfig.KeyringPath == "" {
+			return errors.New("--da.tx-client.keyring-path must be set")
+		}
+		if c.TxClientConfig.CoreGRPCAddr == "" {
+			return errors.New("--da.tx-client.core-grpc.addr must be set")
+		}
+		if c.TxClientConfig.P2PNetwork == "" {
+			return errors.New("--da.tx-client.p2p-network must be set")
+		}
 	}
 	if _, err := url.Parse(c.Rpc); err != nil {
 		return fmt.Errorf("rpc url is invalid: %w", err)
@@ -134,6 +213,14 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 		Namespace:    ctx.String(NamespaceFlagName),
 		FallbackMode: ctx.String(FallbackModeFlagName),
 		GasPrice:     ctx.Float64(GasPriceFlagName),
+		TxClientConfig: TxClientConfig{
+			DefaultKeyName:     ctx.String(DefaultKeyNameFlagName),
+			KeyringPath:        ctx.String(KeyringPathFlagName),
+			CoreGRPCAddr:       ctx.String(CoreGRPCAddrFlagName),
+			CoreGRPCTLSEnabled: ctx.Bool(CoreGRPCTLSEnabledFlagName),
+			CoreGRPCAuthToken:  ctx.String(CoreGRPCAuthTokenFlagName),
+			P2PNetwork:         ctx.String(P2PNetworkFlagName),
+		},
 	}
 }
 
@@ -171,6 +258,25 @@ func ReadCLIConfigFromEnv(envPrefix string) CLIConfig {
 		} else {
 			log.Crit("invalid gas price", "value", value)
 		}
+	}
+
+	if value := os.Getenv(envPrefix + "_" + "DA_TX_CLIENT_KEY_NAME"); value != "" {
+		result.TxClientConfig.DefaultKeyName = value
+	}
+	if value := os.Getenv(envPrefix + "_" + "DA_TX_CLIENT_KEYRING_PATH"); value != "" {
+		result.TxClientConfig.KeyringPath = value
+	}
+	if value := os.Getenv(envPrefix + "_" + "DA_TX_CLIENT_CORE_GRPC_ADDR"); value != "" {
+		result.TxClientConfig.CoreGRPCAddr = value
+	}
+	if value := os.Getenv(envPrefix + "_" + "DA_TX_CLIENT_CORE_GRPC_TLS_ENABLED"); value != "" {
+		result.TxClientConfig.CoreGRPCTLSEnabled = value == "true"
+	}
+	if value := os.Getenv(envPrefix + "_" + "DA_TX_CLIENT_CORE_GRPC_AUTH_TOKEN"); value != "" {
+		result.TxClientConfig.CoreGRPCAuthToken = value
+	}
+	if value := os.Getenv(envPrefix + "_" + "DA_TX_CLIENT_P2P_NETWORK"); value != "" {
+		result.TxClientConfig.P2PNetwork = value
 	}
 
 	return result

--- a/op-celestia/da_client.go
+++ b/op-celestia/da_client.go
@@ -3,11 +3,16 @@ package celestia
 import (
 	"context"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"time"
 
+	txClient "github.com/celestiaorg/celestia-node/api/client"
 	"github.com/celestiaorg/celestia-node/api/rpc/client"
+	blobAPI "github.com/celestiaorg/celestia-node/nodebuilder/blob"
+	"github.com/celestiaorg/celestia-node/nodebuilder/p2p"
+	libshare "github.com/celestiaorg/go-square/v2/share"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // heightLen is a length (in bytes) of serialized height.
@@ -30,8 +35,27 @@ func SplitID(id []byte) (uint64, []byte) {
 	return binary.LittleEndian.Uint64(id[:heightLen]), commitment
 }
 
+type TxClientConfig struct {
+	DefaultKeyName     string
+	KeyringPath        string
+	CoreGRPCAddr       string
+	CoreGRPCTLSEnabled bool
+	CoreGRPCAuthToken  string
+	P2PNetwork         string
+}
+
+type RPCClientConfig struct {
+	URL            string
+	TLSEnabled     bool
+	AuthToken      string
+	Namespace      []byte
+	FallbackMode   string
+	GasPrice       float64
+	TxClientConfig *TxClientConfig
+}
+
 type DAClient struct {
-	Client        *client.Client
+	Client        blobAPI.Module
 	GetTimeout    time.Duration
 	SubmitTimeout time.Duration
 	Namespace     []byte
@@ -39,24 +63,75 @@ type DAClient struct {
 	GasPrice      float64
 }
 
-func NewDAClient(rpc, token, namespace, fallbackMode string, gasPrice float64) (*DAClient, error) {
-	client, err := client.NewClient(context.Background(), rpc, token)
-	if err != nil {
-		return nil, err
+// initTxClient initializes a transaction client for Celestia.
+func initTxClient(cfg RPCClientConfig) (blobAPI.Module, error) {
+	keyname := cfg.TxClientConfig.DefaultKeyName
+	if keyname == "" {
+		keyname = "my_celes_key"
 	}
-	ns, err := hex.DecodeString(namespace)
+	kr, err := txClient.KeyringWithNewKey(txClient.KeyringConfig{
+		KeyName:     keyname,
+		BackendName: keyring.BackendTest,
+	}, cfg.TxClientConfig.KeyringPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create keyring: %w", err)
 	}
-	if fallbackMode != "disabled" && fallbackMode != "blobdata" && fallbackMode != "calldata" {
-		return nil, fmt.Errorf("celestia: unknown fallback mode: %s", fallbackMode)
+
+	// Configure client
+	config := txClient.Config{
+		ReadConfig: txClient.ReadConfig{
+			BridgeDAAddr: cfg.URL,
+			DAAuthToken:  cfg.AuthToken,
+			EnableDATLS:  cfg.TLSEnabled,
+		},
+		SubmitConfig: txClient.SubmitConfig{
+			DefaultKeyName: cfg.TxClientConfig.DefaultKeyName,
+			Network:        p2p.Network(cfg.TxClientConfig.P2PNetwork),
+			CoreGRPCConfig: txClient.CoreGRPCConfig{
+				Addr:       cfg.TxClientConfig.CoreGRPCAddr,
+				TLSEnabled: cfg.TxClientConfig.CoreGRPCTLSEnabled,
+				AuthToken:  cfg.TxClientConfig.CoreGRPCAuthToken,
+			},
+		},
+	}
+	ctx := context.Background()
+	celestiaClient, err := txClient.New(ctx, config, kr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tx client: %w", err)
+	}
+	return celestiaClient.Blob, nil
+}
+
+// initRPCClient initializes an RPC client for Celestia.
+func initRPCClient(cfg RPCClientConfig) (blobAPI.Module, error) {
+	celestiaClient, err := client.NewClient(context.Background(), cfg.URL, cfg.AuthToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rpc client: %w", err)
+	}
+	return &celestiaClient.Blob, nil
+}
+
+func NewDAClient(cfg RPCClientConfig) (*DAClient, error) {
+	var blobClient blobAPI.Module
+	var err error
+	if cfg.TxClientConfig != nil {
+		blobClient, err = initTxClient(cfg)
+	} else {
+		blobClient, err = initRPCClient(cfg)
+	}
+	if err != nil {
+		log.Crit("failed to initialize celestia client", "err", err)
+	}
+	_, err = libshare.NewNamespaceFromBytes(cfg.Namespace)
+	if err != nil {
+		log.Crit("failed to parse namespace", "err", err)
 	}
 	return &DAClient{
-		Client:        client,
+		Client:        blobClient,
 		GetTimeout:    time.Minute,
 		SubmitTimeout: time.Minute,
-		Namespace:     ns,
-		FallbackMode:  fallbackMode,
-		GasPrice:      gasPrice,
+		Namespace:     cfg.Namespace,
+		FallbackMode:  cfg.FallbackMode,
+		GasPrice:      cfg.GasPrice,
 	}, nil
 }

--- a/op-celestia/indexer/driver.go
+++ b/op-celestia/indexer/driver.go
@@ -317,7 +317,7 @@ func (d *IndexerDriver) processCelestiaFrames(id []byte, blockNum uint64) error 
 
 	d.Log.Debug("Found Celestia reference", "height", height, "commitment", base64.StdEncoding.EncodeToString(commitment))
 
-	blob, err := d.CelestiaClient.Client.Blob.Get(ctx, height, namespace, commitment)
+	blob, err := d.CelestiaClient.Client.Get(ctx, height, namespace, commitment)
 	if err != nil {
 		return fmt.Errorf("failed to fetch blobs from Celestia: %w", err)
 	}

--- a/op-celestia/indexer/service.go
+++ b/op-celestia/indexer/service.go
@@ -150,13 +150,7 @@ func (is *IndexerService) initClients(ctx context.Context, cfg *CLIConfig) error
 	is.L2Client = l2RpcClient
 
 	// Initialize Celestia client
-	celestiaClient, err := celestia.NewDAClient(
-		cfg.CelestiaConfig.Rpc,
-		cfg.CelestiaConfig.AuthToken,
-		cfg.CelestiaConfig.Namespace,
-		cfg.CelestiaConfig.FallbackMode,
-		cfg.CelestiaConfig.GasPrice,
-	)
+	celestiaClient, err := celestia.NewDAClient(cfg.CelestiaConfig.CelestiaConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create Celestia client: %w", err)
 	}

--- a/op-node/rollup/derive/celestia_data_source.go
+++ b/op-node/rollup/derive/celestia_data_source.go
@@ -61,7 +61,7 @@ func (s *CelestiaDataSource) Next(ctx context.Context) (eth.Data, error) {
 	if err != nil {
 		return nil, err
 	}
-	blob, err := daClient.Client.Blob.Get(ctx, height, namespace, commitment)
+	blob, err := daClient.Client.Get(ctx, height, namespace, commitment)
 	if err != nil {
 		// return temporary error so we can keep retrying.
 		return nil, NewTemporaryError(fmt.Errorf("celestia: failed to resolve frame: %w", err))

--- a/op-node/rollup/driver/da.go
+++ b/op-node/rollup/driver/da.go
@@ -20,7 +20,7 @@ func SetDAClient(cfg celestia.CLIConfig) error {
 	if !cfg.IsEnabled() {
 		return derive.SetCelestiaDA(nil)
 	}
-	client, err := celestia.NewDAClient(cfg.Rpc, cfg.AuthToken, cfg.Namespace, cfg.FallbackMode, cfg.GasPrice)
+	client, err := celestia.NewDAClient(cfg.CelestiaConfig())
 	if err != nil {
 		return err
 	}

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -41,7 +41,7 @@ func Main(useInterop bool) {
 	preimageHinter := preimage.ClientHinterChannel()
 
 	daCfg := celestia.ReadCLIConfigFromEnv("OP_E2E")
-	daClient, err := celestia.NewDAClient(daCfg.Rpc, daCfg.AuthToken, daCfg.Namespace, daCfg.FallbackMode, daCfg.GasPrice)
+	daClient, err := celestia.NewDAClient(daCfg.CelestiaConfig())
 	if err != nil {
 		log.Error("Cannot initialize daClient", "err", err)
 		os.Exit(1)

--- a/op-program/host/common/common.go
+++ b/op-program/host/common/common.go
@@ -80,7 +80,7 @@ func FaultProofProgram(ctx context.Context, logger log.Logger, cfg *config.Confi
 		}
 
 		daCfg := celestia.ReadCLIConfigFromEnv("OP_E2E")
-		daClient, err := celestia.NewDAClient(daCfg.Rpc, daCfg.AuthToken, daCfg.Namespace, daCfg.FallbackMode, daCfg.GasPrice)
+		daClient, err := celestia.NewDAClient(daCfg.CelestiaConfig())
 		if err != nil {
 			return fmt.Errorf("failed to initialize daClient: %w", err)
 		}


### PR DESCRIPTION
## Overview

This PR adds optional support for [celestia tx client](https://docs.celestia.org/tutorials/golang-client-tutorial) which makes it easier to use RPC services like Quicknode, for example. The existing RPC client compatibility is not affected.